### PR TITLE
[feat] 백엔드 Swagger 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-common:2.2.0'
+
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/postdm/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/postdm/backend/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -51,4 +52,11 @@ public class SecurityConfig { // 시큐리티 설정을 위한 Config
 
         return http.build();
     }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return webSecurity -> webSecurity.ignoring()
+                .requestMatchers("/swagger-ui/**", "/favicon.ico", "/api-docs/**", "/v3/api-docs/**");
+    }
+
 }

--- a/backend/src/main/java/com/postdm/backend/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/postdm/backend/global/config/SwaggerConfig.java
@@ -1,0 +1,46 @@
+package com.postdm.backend.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(customInfo())
+                .addSecurityItem(customSecurityRequirement())
+                .components(customComponents());
+    }
+
+    private Info customInfo() {
+        return new Info()
+                .title("PostDM API Document")
+                .version("1.0")
+                .description("PostDM API 문서");
+    }
+
+    String authName = "Json Web Token";
+
+    private SecurityRequirement customSecurityRequirement() {
+        return new SecurityRequirement().addList(authName);
+    }
+
+    private Components customComponents() {
+        return new Components().addSecuritySchemes(authName,
+                new SecurityScheme()
+                        .name(authName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT")
+                        .description("Access Token을 입력해주세요.(Bearer 제외)")
+        );
+    }
+
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -15,3 +15,17 @@ spring:
   sql:
     init:
       mode: always
+# Swagger 설정
+springdoc:
+  packages-to-scan: com.postdm.backend
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    tags-sorter: method
+    operations-sorter: method
+  api-docs:
+    path: /api-docs/json
+    groups:
+      enabled: true
+  cache:
+    disabled: true


### PR DESCRIPTION
## 📌 개요
- Swagger API 명세서 기능을 추가합니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #13 

## ✅ 변경 사항
- Swagger 의존성 주입
- Swagger Config 작성
- application.yml에 Swagger 문서 설정 추가

## 📝 상세 내용
- http://localhost:8080/swagger-ui/index.html로 접속하면 api 명세서를 확인할 수 있도록 함.