### PR TITLE
[feat] 로그인 및 아이디찾기/비밀번호찾기 UI 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "next": "15.1.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -187,6 +188,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "next": "15.1.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/frontend/src/app/find/page.tsx
+++ b/frontend/src/app/find/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
+import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
 
 const FindPage = () => {
   const router = useRouter();
@@ -11,12 +12,16 @@ const FindPage = () => {
   const [foundId, setFoundId] = useState<string | null>(null);
   const [showVerification, setShowVerification] = useState(false);
   const [isVerified, setIsVerified] = useState(false);
+  const [verificationCode, setVerificationCode] = useState("");
+  const [verificationError, setVerificationError] = useState(false);
 
   const handleTabChange = (newTab: string) => {
     router.push(`/find?tab=${newTab}`);
     setFoundId(null);
     setShowVerification(false);
     setIsVerified(false);
+    setVerificationCode("");
+    setVerificationError(false);
   };
 
   const handleFindId = () => {
@@ -29,7 +34,13 @@ const FindPage = () => {
   };
 
   const handleConfirmVerification = () => {
-    setIsVerified(true);
+    if (verificationCode === "1234") {
+      setIsVerified(true);
+      setVerificationError(false);
+    } else {
+      setIsVerified(false);
+      setVerificationError(true);
+    }
   };
 
   return (
@@ -136,8 +147,18 @@ const FindPage = () => {
                   <input
                     type="text"
                     placeholder="인증번호 입력"
-                    className="w-full border-b border-gray-600 outline-none py-2 text-lg"
+                    value={verificationCode}
+                    onChange={(e) => setVerificationCode(e.target.value)}
+                    className={`flex-grow border-b outline-none py-2 text-lg ${
+                      verificationError ? "border-red-500" : "border-gray-600"
+                    }`}
                   />
+                  {isVerified && (
+                    <CheckCircleIcon className="w-6 h-6 text-green-500 flex-shrink-0 ml-2" />
+                  )}
+                  {verificationError && (
+                    <XCircleIcon className="w-6 h-6 text-red-500 flex-shrink-0 ml-2" />
+                  )}
                   <button
                     className="ml-2 font-bold px-4 py-2 bg-[#353395] text-white rounded-md text-sm whitespace-nowrap"
                     onClick={handleConfirmVerification}
@@ -145,6 +166,11 @@ const FindPage = () => {
                     확인
                   </button>
                 </div>
+                {verificationError && (
+                  <p className="text-red-500 font-semibold text-sm mt-1">
+                    * 인증번호를 다시 확인해주세요.
+                  </p>
+                )}
               </div>
             )}
 

--- a/frontend/src/app/find/page.tsx
+++ b/frontend/src/app/find/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
 import PrimaryButton from "@/components/find/PrimaryButton";
+import InputField from "@/components/find/InputField";
 
 const FindPage = () => {
   const router = useRouter();
@@ -104,72 +105,50 @@ const FindPage = () => {
             </div>
           ) : (
             <div>
-              <label className="block text-left text-lg font-medium text-gray-700">
-                이메일
-              </label>
-              <input
+              <InputField
+                label="이메일"
                 type="email"
                 placeholder="이메일 주소 입력"
-                className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
               />
               <PrimaryButton text="아이디 확인하기" onClick={handleFindId} />
             </div>
           )
         ) : showPasswordReset ? (
           <div>
-            <label className="block text-left text-lg font-medium text-gray-700">
-              변경 비밀번호{" "}
-              <span className="text-sm text-gray-500">
-                *영문 + 숫자 + 특수문자 8자 이상
-              </span>
-            </label>
-            <input
+            <InputField
+              label="변경 비밀번호"
               type="password"
               placeholder="새로 변경할 비밀번호를 입력해주세요"
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
-              className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
+              helperText="*영문 + 숫자 + 특수문자 8자 이상"
             />
 
-            <label className="block text-left text-lg font-medium text-gray-700 mt-6">
-              변경 비밀번호 재확인
-            </label>
-            <input
+            <InputField
+              label="변경 비밀번호 재확인"
               type="password"
               placeholder="비밀번호를 재입력해주세요"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
-              className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
             />
-
             <PrimaryButton text="비밀번호 변경하기" />
           </div>
         ) : (
           <div>
-            <label className="block text-left text-lg font-medium text-gray-700">
-              아이디
-            </label>
-            <input
-              type="text"
-              placeholder="아이디 입력"
-              className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
-            />
-
-            <label className="block text-left text-lg font-medium text-gray-700 mt-6">
-              이메일
-            </label>
+            <InputField label="아이디" type="text" placeholder="아이디 입력" />
             <div className="w-full flex items-center">
-              <input
+              <InputField
+                label="이메일"
                 type="email"
                 placeholder="이메일 주소 입력"
-                className="w-full border-b border-gray-600 outline-none py-2 text-lg"
-              />
-              <button
-                className="ml-2 font-bold px-4 py-2 bg-primary text-white rounded-md text-sm whitespace-nowrap"
-                onClick={handleVerifyEmail}
               >
-                인증
-              </button>
+                <button
+                  className="font-bold px-4 py-2 bg-primary text-white rounded-md text-sm whitespace-nowrap"
+                  onClick={handleVerifyEmail}
+                >
+                  인증
+                </button>
+              </InputField>
             </div>
             {showVerification && (
               <div className="mt-4">
@@ -206,7 +185,6 @@ const FindPage = () => {
                 )}
               </div>
             )}
-
             <PrimaryButton
               text="비밀번호 재설정"
               onClick={handlePasswordReset}

--- a/frontend/src/app/find/page.tsx
+++ b/frontend/src/app/find/page.tsx
@@ -14,6 +14,10 @@ const FindPage = () => {
   const [isVerified, setIsVerified] = useState(false);
   const [verificationCode, setVerificationCode] = useState("");
   const [verificationError, setVerificationError] = useState(false);
+  const [showPasswordReset, setShowPasswordReset] = useState(false);
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
 
   const handleTabChange = (newTab: string) => {
     router.push(`/find?tab=${newTab}`);
@@ -22,6 +26,7 @@ const FindPage = () => {
     setIsVerified(false);
     setVerificationCode("");
     setVerificationError(false);
+    setShowPasswordReset(false);
   };
 
   const handleFindId = () => {
@@ -35,12 +40,17 @@ const FindPage = () => {
 
   const handleConfirmVerification = () => {
     if (verificationCode === "1234") {
+      // 추후 연동 필요, 우선 인증코드가 1234면 통과
       setIsVerified(true);
       setVerificationError(false);
     } else {
       setIsVerified(false);
       setVerificationError(true);
     }
+  };
+
+  const handlePasswordReset = () => {
+    setShowPasswordReset(true);
   };
 
   return (
@@ -111,6 +121,37 @@ const FindPage = () => {
               </button>
             </div>
           )
+        ) : showPasswordReset ? (
+          <div>
+            <label className="block text-left text-lg font-medium text-gray-700">
+              변경 비밀번호{" "}
+              <span className="text-sm text-gray-500">
+                *영문 + 숫자 + 특수문자 8자 이상
+              </span>
+            </label>
+            <input
+              type="password"
+              placeholder="새로 변경할 비밀번호를 입력해주세요"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
+            />
+
+            <label className="block text-left text-lg font-medium text-gray-700 mt-6">
+              변경 비밀번호 재확인
+            </label>
+            <input
+              type="password"
+              placeholder="비밀번호를 재입력해주세요"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
+            />
+
+            <button className="w-full bg-[#353395] font-semibold text-white rounded-full py-2 text-lg mt-6">
+              비밀번호 변경하기
+            </button>
+          </div>
         ) : (
           <div>
             <label className="block text-left text-lg font-medium text-gray-700">
@@ -181,6 +222,7 @@ const FindPage = () => {
                   : "bg-[#353395] text-white opacity-50 cursor-not-allowed"
               }`}
               disabled={!isVerified}
+              onClick={handlePasswordReset}
             >
               비밀번호 재설정
             </button>

--- a/frontend/src/app/find/page.tsx
+++ b/frontend/src/app/find/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+const FindPage = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const tab = searchParams.get("tab") || "id";
+
+  const handleTabChange = (newTab: string) => {
+    router.push(`/find?tab=${newTab}`);
+  };
+
+  return (
+    <div className="flex flex-col items-center w-[390px] h-[844px] mx-auto p-6">
+      <div className="w-full h-16 border-b border-gray-400 flex items-center justify-center text-gray-500">
+        상단바 공간
+      </div>
+
+      <div className="w-full flex border-b">
+        <button
+          onClick={() => handleTabChange("id")}
+          className={`w-1/2 py-3 text-center font-medium border-b-2 ${
+            tab === "id"
+              ? "text-[#353395] border-[#353395] font-semibold"
+              : "text-gray-400 border-gray-400"
+          }`}
+        >
+          아이디 찾기
+        </button>
+        <button
+          onClick={() => handleTabChange("password")}
+          className={`w-1/2 py-3 text-center font-medium border-b-2 ${
+            tab === "password"
+              ? "text-[#353395] border-[#353395] font-semibold"
+              : "text-gray-400 border-gray-400"
+          }`}
+        >
+          비밀번호 찾기
+        </button>
+      </div>
+
+      <div className="w-full mt-6">
+        {tab === "id" ? (
+          <div>
+            <label className="block text-left text-lg font-medium text-gray-700">
+              이메일
+            </label>
+            <input
+              type="email"
+              placeholder="이메일 주소 입력"
+              className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
+            />
+            <button className="w-full bg-[#353395] text-white rounded-full py-2 text-lg mt-6">
+              아이디 확인하기
+            </button>
+          </div>
+        ) : (
+          <div>
+            <label className="block text-left text-lg font-medium text-gray-700">
+              아이디
+            </label>
+            <input
+              type="text"
+              placeholder="아이디 입력"
+              className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
+            />
+
+            <label className="block text-left text-lg font-medium text-gray-700 mt-6">
+              이메일
+            </label>
+            <div className="w-full flex items-center">
+              <input
+                type="email"
+                placeholder="이메일 주소 입력"
+                className="w-full border-b border-gray-600 outline-none py-2 text-lg"
+              />
+              <button className="ml-2 font-bold px-4 py-2 bg-[#353395] text-white rounded-md text-sm whitespace-nowrap">
+                인증
+              </button>
+            </div>
+
+            <button className="w-full bg-[#353395] text-white rounded-full py-2 text-lg mt-6">
+              비밀번호 재설정
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FindPage;

--- a/frontend/src/app/find/page.tsx
+++ b/frontend/src/app/find/page.tsx
@@ -64,7 +64,7 @@ const FindPage = () => {
           onClick={() => handleTabChange("id")}
           className={`w-1/2 py-3 text-center font-medium border-b-2 ${
             tab === "id"
-              ? "text-[#353395] border-[#353395] font-semibold"
+              ? "text-primary border-primary font-semibold"
               : "text-gray-400 border-gray-400"
           }`}
         >
@@ -74,7 +74,7 @@ const FindPage = () => {
           onClick={() => handleTabChange("password")}
           className={`w-1/2 py-3 text-center font-medium border-b-2 ${
             tab === "password"
-              ? "text-[#353395] border-[#353395] font-semibold"
+              ? "text-primary border-primary font-semibold"
               : "text-gray-400 border-gray-400"
           }`}
         >
@@ -86,12 +86,12 @@ const FindPage = () => {
         {tab === "id" ? (
           foundId ? (
             <div className="text-center">
-              <p className="text-[#353395] text-lg font-bold">
+              <p className="text-primary text-lg font-bold">
                 고객님과 일치하는 아이디입니다.
               </p>
               <p className="text-xl font-semibold mt-2"> ID : {foundId}</p>
               <button
-                className="w-full bg-[#353395] font-bold text-white rounded-full py-2 text-lg mt-6"
+                className="w-full bg-primary font-bold text-white rounded-full py-2 text-lg mt-6"
                 onClick={() => router.push("/login")}
               >
                 로그인
@@ -114,7 +114,7 @@ const FindPage = () => {
                 className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
               />
               <button
-                className="w-full bg-[#353395] font-semibold text-white rounded-full py-2 text-lg mt-6"
+                className="w-full bg-primary font-semibold text-white rounded-full py-2 text-lg mt-6"
                 onClick={handleFindId}
               >
                 아이디 확인하기
@@ -148,7 +148,7 @@ const FindPage = () => {
               className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
             />
 
-            <button className="w-full bg-[#353395] font-semibold text-white rounded-full py-2 text-lg mt-6">
+            <button className="w-full bg-primary font-semibold text-white rounded-full py-2 text-lg mt-6">
               비밀번호 변경하기
             </button>
           </div>
@@ -173,7 +173,7 @@ const FindPage = () => {
                 className="w-full border-b border-gray-600 outline-none py-2 text-lg"
               />
               <button
-                className="ml-2 font-bold px-4 py-2 bg-[#353395] text-white rounded-md text-sm whitespace-nowrap"
+                className="ml-2 font-bold px-4 py-2 bg-primary text-white rounded-md text-sm whitespace-nowrap"
                 onClick={handleVerifyEmail}
               >
                 인증
@@ -201,7 +201,7 @@ const FindPage = () => {
                     <XCircleIcon className="w-6 h-6 text-red-500 flex-shrink-0 ml-2" />
                   )}
                   <button
-                    className="ml-2 font-bold px-4 py-2 bg-[#353395] text-white rounded-md text-sm whitespace-nowrap"
+                    className="ml-2 font-bold px-4 py-2 bg-primary text-white rounded-md text-sm whitespace-nowrap"
                     onClick={handleConfirmVerification}
                   >
                     확인
@@ -218,8 +218,8 @@ const FindPage = () => {
             <button
               className={`w-full font-semibold rounded-full py-2 text-lg mt-6 ${
                 isVerified
-                  ? "bg-[#353395] text-white"
-                  : "bg-[#353395] text-white opacity-50 cursor-not-allowed"
+                  ? "bg-primary text-white"
+                  : "bg-primary text-white opacity-50 cursor-not-allowed"
               }`}
               disabled={!isVerified}
               onClick={handlePasswordReset}

--- a/frontend/src/app/find/page.tsx
+++ b/frontend/src/app/find/page.tsx
@@ -1,14 +1,23 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 
 const FindPage = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const tab = searchParams.get("tab") || "id";
 
+  const [foundId, setFoundId] = useState<string | null>(null);
+
   const handleTabChange = (newTab: string) => {
     router.push(`/find?tab=${newTab}`);
+    setFoundId(null);
+  };
+
+  const handleFindId = () => {
+    // 추후 연동 필요
+    setFoundId("ekdm*******");
   };
 
   return (
@@ -42,19 +51,43 @@ const FindPage = () => {
 
       <div className="w-full mt-6">
         {tab === "id" ? (
-          <div>
-            <label className="block text-left text-lg font-medium text-gray-700">
-              이메일
-            </label>
-            <input
-              type="email"
-              placeholder="이메일 주소 입력"
-              className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
-            />
-            <button className="w-full bg-[#353395] text-white rounded-full py-2 text-lg mt-6">
-              아이디 확인하기
-            </button>
-          </div>
+          foundId ? (
+            <div className="text-center">
+              <p className="text-[#353395] text-lg font-bold">
+                고객님과 일치하는 아이디입니다.
+              </p>
+              <p className="text-xl font-semibold mt-2"> ID : {foundId}</p>
+              <button
+                className="w-full bg-[#353395] font-bold text-white rounded-full py-2 text-lg mt-6"
+                onClick={() => router.push("/login")}
+              >
+                로그인
+              </button>
+              <button
+                className="w-full text-sm underline mt-4"
+                onClick={() => handleTabChange("password")}
+              >
+                비밀번호 찾기
+              </button>
+            </div>
+          ) : (
+            <div>
+              <label className="block text-left text-lg font-medium text-gray-700">
+                이메일
+              </label>
+              <input
+                type="email"
+                placeholder="이메일 주소 입력"
+                className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
+              />
+              <button
+                className="w-full bg-[#353395] font-semibold text-white rounded-full py-2 text-lg mt-6"
+                onClick={handleFindId}
+              >
+                아이디 확인하기
+              </button>
+            </div>
+          )
         ) : (
           <div>
             <label className="block text-left text-lg font-medium text-gray-700">
@@ -80,7 +113,7 @@ const FindPage = () => {
               </button>
             </div>
 
-            <button className="w-full bg-[#353395] text-white rounded-full py-2 text-lg mt-6">
+            <button className="w-full bg-[#353395] font-semibold text-white rounded-full py-2 text-lg mt-6">
               비밀번호 재설정
             </button>
           </div>

--- a/frontend/src/app/find/page.tsx
+++ b/frontend/src/app/find/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
+import PrimaryButton from "@/components/find/PrimaryButton";
 
 const FindPage = () => {
   const router = useRouter();
@@ -90,12 +91,10 @@ const FindPage = () => {
                 고객님과 일치하는 아이디입니다.
               </p>
               <p className="text-xl font-semibold mt-2"> ID : {foundId}</p>
-              <button
-                className="w-full bg-primary font-bold text-white rounded-full py-2 text-lg mt-6"
+              <PrimaryButton
+                text="로그인"
                 onClick={() => router.push("/login")}
-              >
-                로그인
-              </button>
+              />
               <button
                 className="w-full text-sm underline mt-4"
                 onClick={() => handleTabChange("password")}
@@ -113,12 +112,7 @@ const FindPage = () => {
                 placeholder="이메일 주소 입력"
                 className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
               />
-              <button
-                className="w-full bg-primary font-semibold text-white rounded-full py-2 text-lg mt-6"
-                onClick={handleFindId}
-              >
-                아이디 확인하기
-              </button>
+              <PrimaryButton text="아이디 확인하기" onClick={handleFindId} />
             </div>
           )
         ) : showPasswordReset ? (
@@ -148,9 +142,7 @@ const FindPage = () => {
               className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
             />
 
-            <button className="w-full bg-primary font-semibold text-white rounded-full py-2 text-lg mt-6">
-              비밀번호 변경하기
-            </button>
+            <PrimaryButton text="비밀번호 변경하기" />
           </div>
         ) : (
           <div>
@@ -215,17 +207,11 @@ const FindPage = () => {
               </div>
             )}
 
-            <button
-              className={`w-full font-semibold rounded-full py-2 text-lg mt-6 ${
-                isVerified
-                  ? "bg-primary text-white"
-                  : "bg-primary text-white opacity-50 cursor-not-allowed"
-              }`}
-              disabled={!isVerified}
+            <PrimaryButton
+              text="비밀번호 재설정"
               onClick={handlePasswordReset}
-            >
-              비밀번호 재설정
-            </button>
+              disabled={!isVerified}
+            />
           </div>
         )}
       </div>

--- a/frontend/src/app/find/page.tsx
+++ b/frontend/src/app/find/page.tsx
@@ -9,15 +9,27 @@ const FindPage = () => {
   const tab = searchParams.get("tab") || "id";
 
   const [foundId, setFoundId] = useState<string | null>(null);
+  const [showVerification, setShowVerification] = useState(false);
+  const [isVerified, setIsVerified] = useState(false);
 
   const handleTabChange = (newTab: string) => {
     router.push(`/find?tab=${newTab}`);
     setFoundId(null);
+    setShowVerification(false);
+    setIsVerified(false);
   };
 
   const handleFindId = () => {
     // 추후 연동 필요
     setFoundId("ekdm*******");
+  };
+
+  const handleVerifyEmail = () => {
+    setShowVerification(true);
+  };
+
+  const handleConfirmVerification = () => {
+    setIsVerified(true);
   };
 
   return (
@@ -108,12 +120,42 @@ const FindPage = () => {
                 placeholder="이메일 주소 입력"
                 className="w-full border-b border-gray-600 outline-none py-2 text-lg"
               />
-              <button className="ml-2 font-bold px-4 py-2 bg-[#353395] text-white rounded-md text-sm whitespace-nowrap">
+              <button
+                className="ml-2 font-bold px-4 py-2 bg-[#353395] text-white rounded-md text-sm whitespace-nowrap"
+                onClick={handleVerifyEmail}
+              >
                 인증
               </button>
             </div>
+            {showVerification && (
+              <div className="mt-4">
+                <label className="block text-left text-lg font-medium text-gray-700">
+                  인증번호
+                </label>
+                <div className="w-full flex items-center">
+                  <input
+                    type="text"
+                    placeholder="인증번호 입력"
+                    className="w-full border-b border-gray-600 outline-none py-2 text-lg"
+                  />
+                  <button
+                    className="ml-2 font-bold px-4 py-2 bg-[#353395] text-white rounded-md text-sm whitespace-nowrap"
+                    onClick={handleConfirmVerification}
+                  >
+                    확인
+                  </button>
+                </div>
+              </div>
+            )}
 
-            <button className="w-full bg-[#353395] font-semibold text-white rounded-full py-2 text-lg mt-6">
+            <button
+              className={`w-full font-semibold rounded-full py-2 text-lg mt-6 ${
+                isVerified
+                  ? "bg-[#353395] text-white"
+                  : "bg-[#353395] text-white opacity-50 cursor-not-allowed"
+              }`}
+              disabled={!isVerified}
+            >
               비밀번호 재설정
             </button>
           </div>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,4 +1,20 @@
+"use client";
+import { useState } from "react";
+
 const LoginPage = () => {
+  const [id, setId] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(false);
+
+  const handleLogin = () => {
+    if (!id || !password) {
+      setError(true);
+      return;
+    }
+    setError(false);
+    console.log("로그인 요청"); // 추후 서버 연동
+  };
+
   return (
     <div className="flex flex-col items-center w-[390px] h-[844px] mx-auto p-6">
       <div className="w-full h-16 border-b border-gray-400 flex items-center justify-center text-gray-500">
@@ -11,8 +27,12 @@ const LoginPage = () => {
         </label>
         <input
           type="text"
+          value={id}
+          onChange={(e) => setId(e.target.value)}
           placeholder="아이디 입력"
-          className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
+          className={`w-full border-b outline-none py-2 text-lg mt-2 ${
+            error ? "border-red-500" : "border-gray-600"
+          }`}
         />
       </div>
 
@@ -22,12 +42,25 @@ const LoginPage = () => {
         </label>
         <input
           type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
           placeholder="비밀번호 입력"
-          className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
+          className={`w-full border-b outline-none py-2 text-lg mt-2 ${
+            error ? "border-red-500" : "border-gray-600"
+          }`}
         />
       </div>
-
-      <button className="w-full font-bold bg-[#353395] text-white rounded-full py-2 text-lg mt-10">
+      {error && (
+        <p className="text-red-500 text-sm mt-4 w-full text-left">
+          * 아이디 또는 비밀번호가 잘못되었습니다.
+          <br />
+          정보를 정확히 입력해주세요.
+        </p>
+      )}
+      <button
+        className="w-full font-bold bg-[#353395] text-white rounded-full py-2 text-lg mt-10"
+        onClick={handleLogin}
+      >
         로그인
       </button>
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 import { useState } from "react";
-
+import { useRouter } from "next/navigation";
 const LoginPage = () => {
   const [id, setId] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState(false);
+  const router = useRouter();
 
   const handleLogin = () => {
     if (!id || !password) {
@@ -67,8 +68,18 @@ const LoginPage = () => {
       <div className="w-full flex justify-between mt-4 text-xs text-gray-700">
         <button className="underline">회원가입</button>
         <div className="flex gap-4">
-          <button className="underline">아이디 찾기</button>
-          <button className="underline">비밀번호 찾기</button>
+          <button
+            className="underline"
+            onClick={() => router.push("/find?tab=id")}
+          >
+            아이디 찾기
+          </button>
+          <button
+            className="underline"
+            onClick={() => router.push("/find?tab=password")}
+          >
+            비밀번호 찾기
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -59,7 +59,7 @@ const LoginPage = () => {
         </p>
       )}
       <button
-        className="w-full font-bold bg-[#353395] text-white rounded-full py-2 text-lg mt-10"
+        className="w-full font-bold bg-primary text-white rounded-full py-2 text-lg mt-10"
         onClick={handleLogin}
       >
         로그인

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,45 @@
+const LoginPage = () => {
+  return (
+    <div className="flex flex-col items-center w-[390px] h-[844px] mx-auto p-6">
+      <div className="w-full h-16 border-b border-gray-400 flex items-center justify-center text-gray-500">
+        상단바 공간
+      </div>
+
+      <div className="w-full mt-8">
+        <label className="block text-left text-lg font-medium text-gray-700">
+          아이디
+        </label>
+        <input
+          type="text"
+          placeholder="아이디 입력"
+          className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
+        />
+      </div>
+
+      <div className="w-full mt-6">
+        <label className="block text-left text-lg font-medium text-gray-700">
+          비밀번호
+        </label>
+        <input
+          type="password"
+          placeholder="비밀번호 입력"
+          className="w-full border-b border-gray-600 outline-none py-2 text-lg mt-2"
+        />
+      </div>
+
+      <button className="w-full font-bold bg-[#353395] text-white rounded-full py-2 text-lg mt-10">
+        로그인
+      </button>
+
+      <div className="w-full flex justify-between mt-4 text-xs text-gray-700">
+        <button className="underline">회원가입</button>
+        <div className="flex gap-4">
+          <button className="underline">아이디 찾기</button>
+          <button className="underline">비밀번호 찾기</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/components/find/InputField.tsx
+++ b/frontend/src/components/find/InputField.tsx
@@ -23,7 +23,9 @@ const InputField = ({
     <div className="flex items-center space-x-2">
       <label className="text-lg font-medium text-gray-700">{label}</label>
       {helperText && (
-        <span className="text-sm text-gray-500">{helperText}</span>
+        <span className="text-sm text-gray-500 whitespace-nowrap">
+          {helperText}
+        </span>
       )}
     </div>
     <div className="w-full flex items-center">

--- a/frontend/src/components/find/InputField.tsx
+++ b/frontend/src/components/find/InputField.tsx
@@ -1,14 +1,6 @@
 "use client";
 
-interface InputFieldProps {
-  label: string;
-  type: string;
-  placeholder: string;
-  value?: string;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  children?: React.ReactNode;
-  helperText?: string;
-}
+import { InputFieldProps } from "@/types/components";
 
 const InputField = ({
   label,

--- a/frontend/src/components/find/InputField.tsx
+++ b/frontend/src/components/find/InputField.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+interface InputFieldProps {
+  label: string;
+  type: string;
+  placeholder: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  children?: React.ReactNode;
+  helperText?: string;
+}
+
+const InputField = ({
+  label,
+  type,
+  placeholder,
+  value,
+  onChange,
+  children,
+  helperText,
+}: InputFieldProps) => (
+  <div className="w-full mt-4">
+    <div className="flex items-center space-x-2">
+      <label className="text-lg font-medium text-gray-700">{label}</label>
+      {helperText && (
+        <span className="text-sm text-gray-500">{helperText}</span>
+      )}
+    </div>
+    <div className="w-full flex items-center">
+      <input
+        type={type}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        className="flex-grow border-b border-gray-600 outline-none py-2 text-lg mt-2"
+      />
+      {children && <div className="ml-2">{children}</div>}
+    </div>
+  </div>
+);
+
+export default InputField;

--- a/frontend/src/components/find/PrimaryButton.tsx
+++ b/frontend/src/components/find/PrimaryButton.tsx
@@ -1,10 +1,5 @@
 "use client";
-
-interface PrimaryButtonProps {
-  text: string;
-  onClick?: () => void;
-  disabled?: boolean;
-}
+import { PrimaryButtonProps } from "@/types/components";
 
 const PrimaryButton = ({
   text,

--- a/frontend/src/components/find/PrimaryButton.tsx
+++ b/frontend/src/components/find/PrimaryButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+interface PrimaryButtonProps {
+  text: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+const PrimaryButton = ({
+  text,
+  onClick,
+  disabled = false,
+}: PrimaryButtonProps) => (
+  <button
+    className={`w-full font-semibold rounded-full py-2 text-lg mt-6 ${
+      disabled
+        ? "bg-primary text-white opacity-50 cursor-not-allowed"
+        : "bg-primary text-white"
+    }`}
+    disabled={disabled}
+    onClick={onClick}
+  >
+    {text}
+  </button>
+);
+
+export default PrimaryButton;

--- a/frontend/src/types/components.ts
+++ b/frontend/src/types/components.ts
@@ -1,0 +1,15 @@
+export interface InputFieldProps {
+  label: string;
+  type: string;
+  placeholder: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  children?: React.ReactNode;
+  helperText?: string;
+}
+
+export interface PrimaryButtonProps {
+  text: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,7 +7,11 @@ module.exports = {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: "#353395",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## 📌 개요
- 로그인 페이지와 아이디찾기/비밀번호찾기 페이지의 UI를 구현하였습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #16 

## ✅ 변경 사항
- 로그인 페이지 구현
- 아이디찾기/비밀번호찾기 페이지 구현

## 📝 상세 내용
- 현재 서버와 연동 작업은 완료되지 않은 상태입니다.
- 따라서 아이디찾기 후 나오는 아이디는 ekdm******* 로 고정되어 있습니다.
- 비밀번호찾기에서 이메일 인증 후 입력하는 인증코드 또한 1234가 정답인것으로 고정되어 있습니다.
- 저희 서비스의 메인 색상인 #353395 을 primary 로 설정해두었습니다. text-primary, bg-primary 와 같이 사용하시면 됩니다.
- 상단바는 세영님이 작업하신 부분이라 우선 '상단바 공간'으로 비워두었습니다.

## 📸 스크린샷

### 🔑 로그인 페이지
| ![image](https://github.com/user-attachments/assets/3045aa76-2e08-46b2-92f6-7faee000de75) | ![image](https://github.com/user-attachments/assets/285eabbe-289a-4239-bec6-71564991b96a) |
|---|---|

### 🔍 아이디 찾기 페이지
| ![image](https://github.com/user-attachments/assets/89bc86f2-93a7-4514-a58e-78a7c122eed4) | ![image](https://github.com/user-attachments/assets/29931136-05a1-472a-b0c1-f968bada614c) |
|---|---|

### 🔒 비밀번호 찾기 페이지
| ![image](https://github.com/user-attachments/assets/92bb3b55-ea57-4e62-90a0-3ef8bdff7762) | ![image](https://github.com/user-attachments/assets/d9b8d7ad-3472-431b-9c1c-5d33e794e9af) | ![image](https://github.com/user-attachments/assets/17fdc14a-9ccc-4600-a99f-1ee1ab338630) | ![image](https://github.com/user-attachments/assets/ca64c8c1-f0a5-4da3-a15e-e22a99d1b3a2) |
|---|---|---|---|
