### PR TITLE
[feat] 사용자 역할 기반 견적서 조회 및 작성 기능 구현

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -40,9 +40,14 @@ jobs:
       - name: Grant execute permission for gradlew # 실행 권한
         run: chmod +x backend/gradlew
 
-      - name: Build project (Without Tests)
+#      - name: Build project (Without Tests)
+#        working-directory: backend
+#        run: ./gradlew clean build -x test
+
+      # 테스트 실행 및 JaCoCo 리포트 생성
+      - name: Run Tests & Generate JaCoCo Coverage Report
         working-directory: backend
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean test jacocoTestReport
 
       - name: Build and analyze (Backend)
         working-directory: backend

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,57 +1,58 @@
-name: SonarQube
-
-on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    types: [opened, synchronize, reopened]
-
-jobs:
-  backend-sonar:
-    name: Backend SonarCloud Analysis
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin' # Alternative distribution options are available
-
-      - name: Cache SonarQube packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-
-      - name: Grant execute permission for gradlew # 실행 권한
-        run: chmod +x backend/gradlew
-
-#      - name: Build project (Without Tests)
+#name: SonarQube
+#
+#on:
+#  push:
+#    branches:
+#      - main
+#      - develop
+#  pull_request:
+#    types: [opened, synchronize, reopened]
+#
+#jobs:
+#  backend-sonar:
+#    name: Backend SonarCloud Analysis
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+#
+#      - name: Set up JDK 17
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: 17
+#          distribution: 'temurin' # Alternative distribution options are available
+#
+#      - name: Cache SonarQube packages
+#        uses: actions/cache@v4
+#        with:
+#          path: ~/.sonar/cache
+#          key: ${{ runner.os }}-sonar
+#          restore-keys: ${{ runner.os }}-sonar
+#
+#      - name: Cache Gradle packages
+#        uses: actions/cache@v4
+#        with:
+#          path: ~/.gradle/caches
+#          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+#          restore-keys: ${{ runner.os }}-gradle
+#
+#      - name: Grant execute permission for gradlew # 실행 권한
+#        run: chmod +x backend/gradlew
+#
+#      # 테스트 없이 프로젝트 빌드
+##      - name: Build project (Without Tests)
+##        working-directory: backend
+##        run: ./gradlew clean build -x test
+#
+#      # 테스트 실행 및 JaCoCo 리포트 생성
+#      - name: Run Tests & Generate JaCoCo Coverage Report
 #        working-directory: backend
-#        run: ./gradlew clean build -x test
-
-      # 테스트 실행 및 JaCoCo 리포트 생성
-      - name: Run Tests & Generate JaCoCo Coverage Report
-        working-directory: backend
-        run: ./gradlew clean test jacocoTestReport
-
-      - name: Build and analyze (Backend)
-        working-directory: backend
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew sonar --info
+#        run: ./gradlew clean test jacocoTestReport
+#
+#      - name: Build and analyze (Backend)
+#        working-directory: backend
+#        env:
+#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: ./gradlew sonar --info

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 src/main/resources/application-dev.yml
 src/main/resources/application-prod.yml
+src/main/resources/application-test.yml

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'com.h2database:h2' //테스트 환경 h2 DB
+	testImplementation 'org.assertj:assertj-core:3.24.2' //테스트 검증을 위한 AssertJ 라이브러리
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -3,8 +3,8 @@ plugins {
 	id 'org.springframework.boot' version '3.4.2'
 	id 'io.spring.dependency-management' version '1.1.7'
 
-	id "org.sonarqube" version "6.0.1.5171"
-	id 'jacoco'
+	//id "org.sonarqube" version "6.0.1.5171"
+	//id 'jacoco'
 }
 
 group = 'com.postdm'
@@ -60,20 +60,22 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
-// SonarQube 설정
-sonar {
-	properties {
-		property "sonar.projectKey", "fullstack-dev-hub-0106_postdm-backend"
-		property "sonar.organization", "fullstack-dev-hub-0106"
-		property "sonar.host.url", "https://sonarcloud.io"
-		property "sonar.sources", "src/main/java"
-		property "sonar.tests", "src/test/java"
-		//property "sonar.java.binaries", "build/classes"
-		property "sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath
-		property "sonar.coverage.exclusions", "**/config/**, **/dto/**, **/entity/**"
-	}
-}
 
+// // SonarQube 설정
+//sonar {
+//	properties {
+//		property "sonar.projectKey", "fullstack-dev-hub-0106_postdm-backend"
+//		property "sonar.organization", "fullstack-dev-hub-0106"
+//		property "sonar.host.url", "https://sonarcloud.io"
+//		property "sonar.sources", "src/main/java"
+//		property "sonar.tests", "src/test/java"
+//		//property "sonar.java.binaries", "build/classes"
+//		property "sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath
+//		property "sonar.coverage.exclusions", "**/config/**, **/dto/**, **/entity/**"
+//	}
+//}
+
+/*
 // jacoco 설정
 jacoco {
 	toolVersion = "0.8.8"
@@ -92,3 +94,4 @@ jacocoTestReport {
 		csv.required = false
 	}
 }
+*/

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 
 	id "org.sonarqube" version "6.0.1.5171"
+	id 'jacoco'
 }
 
 group = 'com.postdm'
@@ -67,7 +68,27 @@ sonar {
 		property "sonar.host.url", "https://sonarcloud.io"
 		property "sonar.sources", "src/main/java"
 		property "sonar.tests", "src/test/java"
-		property "sonar.java.binaries", "build/classes"
+		//property "sonar.java.binaries", "build/classes"
+		property "sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath
 		property "sonar.coverage.exclusions", "**/config/**, **/dto/**, **/entity/**"
+	}
+}
+
+// jacoco 설정
+jacoco {
+	toolVersion = "0.8.8"
+}
+
+test {
+	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+		html.required = true
+		csv.required = false
 	}
 }

--- a/backend/src/main/java/com/postdm/backend/domain/auth/api/TestController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/api/TestController.java
@@ -12,6 +12,8 @@ public class TestController { // 현재 사용자 세션 확인용 테스트 컨
     public ResponseTemplate<String> test() {
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
 
-        return new ResponseTemplate<>(HttpStatus.OK, "환영합니다, " + username + "님!", username);
+        String role = SecurityContextHolder.getContext().getAuthentication().getAuthorities().iterator().next().getAuthority();
+
+        return new ResponseTemplate<>(HttpStatus.OK, "환영합니다, " + role + ", " + username + "님!", username);
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/auth/application/AuthService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/application/AuthService.java
@@ -114,7 +114,9 @@ public class AuthService { // 로그인 및 회원가입 서비스
             throw new IllegalArgumentException("아이디 또는 비밀번호가 잘못되었습니다.");
         }
 
-        TokenInfo token = jwtProvider.generateToken(username); // 로그인이 완료되면 토큰 생성
+        String role = member.getRole().name();
+
+        TokenInfo token = jwtProvider.generateToken(username, role); // 로그인이 완료되면 토큰 생성
         String refreshToken = token.getRefreshToken();
 
         response.addCookie(createCookie("Refresh", refreshToken)); // 쿠키에 refresh 토큰 담음

--- a/backend/src/main/java/com/postdm/backend/domain/auth/dto/SignInRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/dto/SignInRequestDto.java
@@ -9,8 +9,4 @@ public class SignInRequestDto { // 로그인 데이터 전송을 위한 DTO
 
     private String password;
 
-    private String email;
-
-    private String certificationNumber;
-
 }

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/controller/EstimateController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/controller/EstimateController.java
@@ -1,0 +1,39 @@
+package com.postdm.backend.domain.estimate.controller;
+
+import com.postdm.backend.domain.estimate.dto.EstimateRequestDto;
+import com.postdm.backend.domain.estimate.dto.EstimateResponseDto;
+import com.postdm.backend.domain.estimate.service.EstimateService;
+import com.postdm.backend.domain.member.domain.entity.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@Tag(name = "Estimate API", description = "견적서 관련 API")
+@RestController
+@RequestMapping("/api/v1/estimates")
+public class EstimateController {
+
+    private final EstimateService estimateService;
+
+    public EstimateController(EstimateService estimateService) {
+        this.estimateService = estimateService;
+    }
+
+    @Operation(summary = "견적서 생성", description = "새로운 견적서를 생성합니다. 사용자는 content만 입력하며, title은 자동 생성됩니다.")
+    @PostMapping
+    public EstimateResponseDto createEstimate(@AuthenticationPrincipal Member currentUser,
+                                              @RequestBody EstimateRequestDto requestDto) {
+        return estimateService.createEstimate(requestDto.getContent(), currentUser);
+    }
+
+    @Operation(summary = "견적서 조회", description = "관리자는 모든 견적서를, 사용자는 본인의 견적서만 조회합니다.")
+    @GetMapping
+    public List<EstimateResponseDto> getEstimates(@AuthenticationPrincipal Member currentUser) {
+        return estimateService.getEstimates(currentUser);
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateRequestDto.java
@@ -2,10 +2,14 @@ package com.postdm.backend.domain.estimate.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Schema(description = "견적서 생성 요청 DTO")
+@NoArgsConstructor // 기본 생성자 추가
+@AllArgsConstructor
 public class EstimateRequestDto {
     @Schema(description = "견적서 내용", example = "이것은 견적서의 내용입니다.")
     @NotBlank(message = "내용은 필수 입력값입니다.")

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateRequestDto.java
@@ -1,0 +1,13 @@
+package com.postdm.backend.domain.estimate.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "견적서 생성 요청 DTO")
+public class EstimateRequestDto {
+    @Schema(description = "견적서 내용", example = "이것은 견적서의 내용입니다.")
+    @NotBlank(message = "내용은 필수 입력값입니다.")
+    private String content;
+}

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateResponseDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateResponseDto.java
@@ -12,7 +12,7 @@ public class EstimateResponseDto {
     @Schema(description = "견적서 ID", example = "1")
     private Long id;
 
-    @Schema(description = "견적서 제목 (내용 앞 10글자 + *** 자동 생성)", example = "이것은 견적서 ***")
+    @Schema(description = "견적서 제목 (내용 앞 10글자 + ... 자동 생성)", example = "이것은 견적서의 내...")
     private String title;
 
     @Schema(description = "견적서 내용", example = "이것은 견적서의 내용입니다.")

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateResponseDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateResponseDto.java
@@ -1,0 +1,34 @@
+package com.postdm.backend.domain.estimate.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "견적서 응답 DTO")
+public class EstimateResponseDto {
+
+    @Schema(description = "견적서 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "견적서 제목 (내용 앞 10글자 + *** 자동 생성)", example = "이것은 견적서 ***")
+    private String title;
+
+    @Schema(description = "견적서 내용", example = "이것은 견적서의 내용입니다.")
+    private String content;
+
+    @Schema(description = "생성 날짜", example = "2024-02-18T12:34:56")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "작성자", example = "user1")
+    private Long memberId;
+
+    public EstimateResponseDto(Long id, String title, String content, LocalDateTime createdAt, Long memberId) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.memberId = memberId;
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/entity/Estimate.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/entity/Estimate.java
@@ -1,0 +1,52 @@
+package com.postdm.backend.domain.estimate.entity;
+
+import com.postdm.backend.domain.member.domain.entity.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "estimate")
+public class Estimate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    private LocalDateTime createdAt;
+
+    public Estimate(String content, Member member) {
+        this.title = generateTitle(content);
+        this.content = content;
+        this.member = member;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public boolean isOwner(Member member) {
+        return this.member.equals(member);
+    }
+
+    public void update(String content) {
+        this.title = generateTitle(content);
+        this.content = content;
+    }
+
+    private String generateTitle(String content) {
+        return content.length() > 10 ? content.substring(0, 10) + "..." : content;
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/entity/EstimateRepository.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/entity/EstimateRepository.java
@@ -1,0 +1,9 @@
+package com.postdm.backend.domain.estimate.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EstimateRepository extends JpaRepository<Estimate, Long> {
+    List<Estimate> findByMemberId(Long memberId);
+}

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/service/EstimateService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/service/EstimateService.java
@@ -32,6 +32,10 @@ public class EstimateService {
     }
 
     public EstimateResponseDto createEstimate(String content, Member member) {
+        if (content == null || content.trim().isEmpty()) {
+            throw new IllegalArgumentException("견적서 내용은 비어 있을 수 없습니다.");
+        }
+
         if (member == null) {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
             if (authentication != null && authentication.getPrincipal() instanceof Member) {

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/service/EstimateService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/service/EstimateService.java
@@ -1,0 +1,84 @@
+package com.postdm.backend.domain.estimate.service;
+
+import com.postdm.backend.domain.estimate.dto.EstimateResponseDto;
+import com.postdm.backend.domain.estimate.entity.Estimate;
+import com.postdm.backend.domain.estimate.entity.EstimateRepository;
+import com.postdm.backend.domain.estimate.service.policy.AdminEstimatePolicy;
+import com.postdm.backend.domain.estimate.service.policy.UserEstimatePolicy;
+import com.postdm.backend.domain.member.domain.entity.Member;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.postdm.backend.domain.member.domain.entity.MemberRole.ADMIN;
+
+@Slf4j
+@Service
+public class EstimateService {
+    private final EstimateRepository estimateRepository;
+    private final AdminEstimatePolicy adminPolicy;
+    private final UserEstimatePolicy userPolicy;
+
+    public EstimateService(EstimateRepository estimateRepository,
+                           AdminEstimatePolicy adminPolicy,
+                           UserEstimatePolicy userPolicy) {
+        this.estimateRepository = estimateRepository;
+        this.adminPolicy = adminPolicy;
+        this.userPolicy = userPolicy;
+    }
+
+    public EstimateResponseDto createEstimate(String content, Member member) {
+        if (member == null) {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication != null && authentication.getPrincipal() instanceof Member) {
+                member = (Member) authentication.getPrincipal();
+            } else {
+                throw new RuntimeException("인증된 사용자가 존재하지 않습니다.");
+            }
+        }
+
+        Estimate estimate = new Estimate(content, member);
+        Estimate savedEstimate = estimateRepository.save(estimate);
+
+        return new EstimateResponseDto(
+            savedEstimate.getId(),
+            savedEstimate.getTitle(),
+            savedEstimate.getContent(),
+            savedEstimate.getCreatedAt(),
+            savedEstimate.getMember().getId()
+        );
+    }
+
+    public List<EstimateResponseDto> getEstimates(Member member) {
+        if (member == null) {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication != null && authentication.getPrincipal() instanceof Member) {
+                member = (Member) authentication.getPrincipal();
+            } else {
+                throw new RuntimeException("인증된 사용자가 존재하지 않습니다.");
+            }
+        }
+
+        List<Estimate> estimates;
+
+        if (member.getRole() == ADMIN) {
+            estimates = adminPolicy.getEstimates(member, estimateRepository);
+        } else {
+            estimates = userPolicy.getEstimates(member, estimateRepository);
+        }
+
+        return estimates.stream()
+                .map(estimate -> new EstimateResponseDto(
+                        estimate.getId(),
+                        estimate.getTitle(),
+                        estimate.getContent(),
+                        estimate.getCreatedAt(),
+                        estimate.getMember().getId()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/AdminEstimatePolicy.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/AdminEstimatePolicy.java
@@ -1,0 +1,16 @@
+package com.postdm.backend.domain.estimate.service.policy;
+
+import com.postdm.backend.domain.estimate.entity.Estimate;
+import com.postdm.backend.domain.estimate.entity.EstimateRepository;
+import com.postdm.backend.domain.member.domain.entity.Member;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class AdminEstimatePolicy implements EstimatePolicy {
+    @Override
+    public List<Estimate> getEstimates(Member member, EstimateRepository repository) {
+        return repository.findAll(); // 관리자: 전체 조회
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/EstimatePolicy.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/EstimatePolicy.java
@@ -1,0 +1,11 @@
+package com.postdm.backend.domain.estimate.service.policy;
+
+import com.postdm.backend.domain.estimate.entity.Estimate;
+import com.postdm.backend.domain.estimate.entity.EstimateRepository;
+import com.postdm.backend.domain.member.domain.entity.Member;
+
+import java.util.List;
+
+public interface EstimatePolicy {
+    List<Estimate> getEstimates(Member member, EstimateRepository repository);
+}

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/UserEstimatePolicy.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/UserEstimatePolicy.java
@@ -1,0 +1,16 @@
+package com.postdm.backend.domain.estimate.service.policy;
+
+import com.postdm.backend.domain.estimate.entity.Estimate;
+import com.postdm.backend.domain.estimate.entity.EstimateRepository;
+import com.postdm.backend.domain.member.domain.entity.Member;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class UserEstimatePolicy implements EstimatePolicy {
+    @Override
+    public List<Estimate> getEstimates(Member member, EstimateRepository repository) {
+        return repository.findByMemberId(member.getId()); // 일반 유저: 본인만 조회
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/postdm/backend/global/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig { // 시큐리티 설정을 위한 Config
         http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll() // /api/v1/auth로 시작하는 경로는 모두 허용(회원가입, 로그인 등)
+                        .requestMatchers("/api/v1/estimates/**").hasAnyRole("MEMBER", "ADMIN") // 견적서 API는 MEMBER와 ADMIN만 접근 가능
                         .anyRequest().authenticated() // 이외의 경로는 인증을 필요로함.
                 );
 

--- a/backend/src/main/java/com/postdm/backend/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/postdm/backend/global/jwt/filter/JwtAuthenticationFilter.java
@@ -31,9 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter { // JWT 필�
             Authentication auth = jwtProvider.getAuthentication(token); // 사용자 추출
             SecurityContextHolder.getContext().setAuthentication(auth); // SecurityContextHolder에 사용자 등록
         }
-        else {
-            log.warn("[JwtAuthenticationFilter] Invalid or missing token.");
-        }
+
         filterChain.doFilter(request, response);
     }
 

--- a/backend/src/main/java/com/postdm/backend/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/postdm/backend/global/jwt/filter/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -14,6 +15,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter { // JWT 필터. 해당 필터를 통해 JWT가 유효한지 판단
@@ -28,6 +30,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter { // JWT 필�
         if (token != null && jwtProvider.validateToken(token)) {
             Authentication auth = jwtProvider.getAuthentication(token); // 사용자 추출
             SecurityContextHolder.getContext().setAuthentication(auth); // SecurityContextHolder에 사용자 등록
+        }
+        else {
+            log.warn("[JwtAuthenticationFilter] Invalid or missing token.");
         }
         filterChain.doFilter(request, response);
     }

--- a/backend/src/main/java/com/postdm/backend/global/jwt/util/JwtProvider.java
+++ b/backend/src/main/java/com/postdm/backend/global/jwt/util/JwtProvider.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -14,6 +16,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -31,12 +34,13 @@ public class JwtProvider { // JWT 발급을 위한 Provider
         this.refreshedMs = refreshedMs;
     }
 
-    public String generateAccessToken(String username) { // AccessToken 생성
+    public String generateAccessToken(String username, String role) { // AccessToken 생성
         Date now = new Date();
         Date accessTokenExpiredAt = new Date(now.getTime() + expiredMs);
 
         return Jwts.builder()
                 .subject(username)
+                .claim("role", role)
                 .issuedAt(now)
                 .expiration(accessTokenExpiredAt)
                 .signWith(secretKey)
@@ -79,9 +83,9 @@ public class JwtProvider { // JWT 발급을 위한 Provider
         return false;
     }
 
-    public TokenInfo generateToken(String username) { // 토큰 생성
+    public TokenInfo generateToken(String username, String role) { // 토큰 생성
 
-        String accessToken = generateAccessToken(username);
+        String accessToken = generateAccessToken(username, role);
         String refreshToken = generateRefreshToken(username);
 
         return TokenInfo.builder()
@@ -95,7 +99,9 @@ public class JwtProvider { // JWT 발급을 위한 Provider
         Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
 
         String username = claims.getSubject();
+        String role = claims.get("role", String.class);  // role 추출
+        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
 
-        return new UsernamePasswordAuthenticationToken(username, "", Collections.emptyList());
+        return new UsernamePasswordAuthenticationToken(username, "", authorities);
     }
 }

--- a/backend/src/main/java/com/postdm/backend/global/jwt/util/JwtProvider.java
+++ b/backend/src/main/java/com/postdm/backend/global/jwt/util/JwtProvider.java
@@ -1,5 +1,7 @@
 package com.postdm.backend.global.jwt.util;
 
+import com.postdm.backend.domain.member.domain.entity.Member;
+import com.postdm.backend.domain.member.domain.repository.MemberRepository;
 import com.postdm.backend.global.jwt.dto.TokenInfo;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SecurityException;
@@ -28,10 +30,13 @@ public class JwtProvider { // JWT 발급을 위한 Provider
 
     private final long refreshedMs;
 
-    public JwtProvider(@Value("${jwt.secret}")String secret, @Value("${jwt.expiredMS}") long expiredMs, @Value("${jwt.refreshedMs}") long refreshedMs) {
+    private final MemberRepository memberRepository;
+
+    public JwtProvider(@Value("${jwt.secret}")String secret, @Value("${jwt.expiredMS}") long expiredMs, @Value("${jwt.refreshedMs}") long refreshedMs, MemberRepository memberRepository) {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
         this.expiredMs = expiredMs;
         this.refreshedMs = refreshedMs;
+        this.memberRepository = memberRepository;
     }
 
     public String generateAccessToken(String username, String role) { // AccessToken 생성
@@ -99,9 +104,17 @@ public class JwtProvider { // JWT 발급을 위한 Provider
         Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
 
         String username = claims.getSubject();
-        String role = claims.get("role", String.class);  // role 추출
-        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
 
-        return new UsernamePasswordAuthenticationToken(username, "", authorities);
+        String role = claims.get("role", String.class);  // role 추출
+
+        Member member = memberRepository.findByUsername(username);
+        if (member == null) {
+            throw new RuntimeException("해당 사용자 정보를 찾을 수 없습니다.");
+        }
+
+        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role));
+
+        // Spring Security에서 Authentication 객체의 principal을 Member 객체로 저장
+        return new UsernamePasswordAuthenticationToken(member, "", authorities);
     }
 }

--- a/backend/src/test/java/com/postdm/backend/domain/estimate/controller/EstimateControllerTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/estimate/controller/EstimateControllerTest.java
@@ -1,0 +1,115 @@
+package com.postdm.backend.domain.estimate.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.postdm.backend.domain.estimate.dto.EstimateRequestDto;
+import com.postdm.backend.domain.estimate.entity.Estimate;
+import com.postdm.backend.domain.estimate.entity.EstimateRepository;
+import com.postdm.backend.domain.estimate.service.EstimateService;
+import com.postdm.backend.domain.member.domain.entity.Member;
+import com.postdm.backend.domain.member.domain.entity.MemberRole;
+import com.postdm.backend.domain.member.domain.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class EstimateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EstimateRepository estimateRepository;
+
+    @Mock
+    private EstimateService estimateService;
+
+    @InjectMocks
+    private EstimateController estimateController;
+
+    private Member testMember;
+    private Estimate testEstimate;
+
+    @BeforeEach
+    void setUp() {
+        estimateRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        testMember = new Member(0L, "testUser", "test1", "password", "test@example.com", "01011111111", MemberRole.MEMBER);
+        testMember = memberRepository.saveAndFlush(testMember);
+
+        testEstimate = new Estimate("테스트 견적 내용입니다.", testMember);
+        estimateRepository.saveAndFlush(testEstimate);
+
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                testMember, null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_MEMBER"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    @DisplayName("견적서 생성 API 테스트")
+    void 견적서_생성_API_테스트() throws Exception {
+        // Given
+        String requestJson = objectMapper.writeValueAsString(new EstimateRequestDto("테스트 견적서 내용입니다."));
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/estimates")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").value("테스트 견적서 내용입니다."));
+    }
+
+    @Test
+    @DisplayName("견적서 조회 API 테스트")
+    void 견적서_조회_API_테스트() throws Exception {
+        // When & Then
+        mockMvc.perform(get("/api/v1/estimates")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(1))
+                .andExpect(jsonPath("$[0].content").value("테스트 견적 내용입니다."));
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자가 견적서를 조회하면 403 응답을 반환해야 한다")
+    void 인증되지_않은_사용자가_견적서를_조회하면_403_반환() throws Exception {
+        SecurityContextHolder.clearContext();
+
+        mockMvc.perform(get("/api/v1/estimates")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/postdm/backend/domain/estimate/repository/EstimateRepositoryTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/estimate/repository/EstimateRepositoryTest.java
@@ -1,0 +1,91 @@
+package com.postdm.backend.domain.estimate.repository;
+
+import com.postdm.backend.domain.estimate.entity.Estimate;
+import com.postdm.backend.domain.estimate.entity.EstimateRepository;
+import com.postdm.backend.domain.member.domain.entity.Member;
+import com.postdm.backend.domain.member.domain.entity.MemberRole;
+import com.postdm.backend.domain.member.domain.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Transactional
+class EstimateRepositoryTest {
+
+    @Autowired
+    private EstimateRepository estimateRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member testMember;
+    private Estimate testEstimate;
+
+    @BeforeEach
+    void setUp() {
+        estimateRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        testMember = new Member(0L, "testUser", "test1", "password", "test@example.com", "01011111111", MemberRole.MEMBER);
+        testMember = memberRepository.saveAndFlush(testMember);
+
+        testEstimate = new Estimate("테스트 견적 내용입니다.", testMember);
+        estimateRepository.saveAndFlush(testEstimate);
+    }
+
+    @Test
+    @DisplayName("견적서를 저장하고 조회할 수 있다")
+    void 견적서를_저장하고_조회() {
+        // When
+        Estimate foundEstimate = estimateRepository.findById(testEstimate.getId()).orElse(null);
+
+        // Then
+        assertThat(foundEstimate).isNotNull();
+        assertThat(foundEstimate.getContent()).isEqualTo(testEstimate.getContent());
+        assertThat(foundEstimate.getMember().getId()).isEqualTo(testMember.getId());
+    }
+
+    @Test
+    @DisplayName("사용자 ID로 견적서를 조회할 수 있다")
+    void 사용자_ID로_견적서를_조회() {
+        // When
+        List<Estimate> estimates = estimateRepository.findByMemberId(testMember.getId());
+
+        // Then
+        assertThat(estimates).isNotEmpty();
+        assertThat(estimates.get(0).getContent()).isEqualTo(testEstimate.getContent());
+        assertThat(estimates.get(0).getMember().getId()).isEqualTo(testMember.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 견적서를 조회하면 빈 값이 반환된다")
+    void 존재하지_않는_견적서를_조회하면_빈값이_반환() {
+        // When
+        Optional<Estimate> estimate = estimateRepository.findById(999L); // 없는 ID 조회
+
+        // Then
+        assertThat(estimate).isEmpty();
+    }
+
+    @Test
+    @DisplayName("견적서를 삭제할 수 있다")
+    void 견적서를_삭제() {
+        // When
+        estimateRepository.delete(testEstimate);
+        Optional<Estimate> deletedEstimate = estimateRepository.findById(testEstimate.getId());
+
+        // Then
+        assertThat(deletedEstimate).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/postdm/backend/domain/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/estimate/service/EstimateServiceTest.java
@@ -1,0 +1,116 @@
+package com.postdm.backend.domain.estimate.service;
+
+import com.postdm.backend.domain.estimate.dto.EstimateRequestDto;
+import com.postdm.backend.domain.estimate.dto.EstimateResponseDto;
+import com.postdm.backend.domain.estimate.entity.Estimate;
+import com.postdm.backend.domain.estimate.entity.EstimateRepository;
+import com.postdm.backend.domain.member.domain.entity.Member;
+import com.postdm.backend.domain.member.domain.entity.MemberRole;
+import com.postdm.backend.domain.member.domain.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class EstimateServiceTest {
+
+    @Autowired
+    private EstimateService estimateService;
+
+    @Autowired
+    private EstimateRepository estimateRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member testMember;
+    private Estimate testEstimate;
+
+    @BeforeEach
+    void setUp() {
+        estimateRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        testMember = new Member(0L, "testUser", "test1", "password", "test@example.com", "01011111111", MemberRole.MEMBER);
+        testMember = memberRepository.saveAndFlush(testMember);
+
+        testEstimate = new Estimate("테스트 견적 내용입니다.", testMember);
+        estimateRepository.saveAndFlush(testEstimate);
+
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                testMember, null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_MEMBER"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    @DisplayName("견적서를 생성하면 정상적으로 반환해야 한다")
+    void 견적서를_생성하면_정상적으로_반환() {
+        // Given
+        EstimateRequestDto requestDto = new EstimateRequestDto("새로운 견적서 내용입니다.");
+
+        // When
+        EstimateResponseDto responseDto = estimateService.createEstimate(requestDto.getContent(), testMember);
+
+        // Then
+        assertThat(responseDto).isNotNull();
+        assertThat(responseDto.getContent()).isEqualTo("새로운 견적서 내용입니다.");
+        assertThat(responseDto.getMemberId()).isEqualTo(testMember.getId());
+    }
+
+    @Test
+    @DisplayName("비어 있는 내용으로 견적서를 생성하면 예외가 발생해야 한다")
+    void 비어있는_내용으로_견적서를_생성하면_예외가_발생() {
+        EstimateRequestDto requestDto = new EstimateRequestDto("");
+
+        assertThrows(RuntimeException.class, () -> {
+            estimateService.createEstimate(requestDto.getContent(), testMember);
+        });
+    }
+
+    @Test
+    @DisplayName("사용자가 본인의 견적서를 조회할 수 있다")
+    void 사용자가_본인의_견적서를_조회() {
+        // When
+        List<EstimateResponseDto> estimates = estimateService.getEstimates(testMember);
+
+        // Then
+        assertThat(estimates).isNotEmpty();
+        assertThat(estimates.get(0).getContent()).isEqualTo(testEstimate.getContent());
+        assertThat(estimates.get(0).getMemberId()).isEqualTo(testMember.getId());
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자가 견적서를 조회하면 예외가 발생해야 한다")
+    void 인증되지_않은_사용자가_견적서를_조회하면_예외_발생() {
+        // Given: 인증 정보 제거
+        SecurityContextHolder.clearContext();
+
+        // When & Then: 인증되지 않은 사용자일 경우 예외 발생
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            estimateService.getEstimates(null);
+        });
+
+        assertThat(exception.getMessage()).isEqualTo("인증된 사용자가 존재하지 않습니다.");
+    }
+}


### PR DESCRIPTION
## 📌 개요
- 사용자 역할(ADMIN, MEMBER)에 따라 견적서 조회 권한을 다르게 구현
- 견적서 작성 기능 구현

## 🚀 관련 이슈
- 관련된 이슈 번호: #17 

## ✅ 변경 사항
**견적서 생성 (POST /api/v1/estimates)**
- title 자동 생성 (content 앞 10글자 + "...")

[Request body]
```
{
  "content": "이것은 견적서의 내용입니다."
}
```

[Response body]
```
{
  "id": 1,
  "title": "이것은 견적서의 내...",
  "content": "이것은 견적서의 내용입니다.",
  "createdAt": "2025-02-25T12:16:03.996Z",
  "memberId": 0
}
```

**견적서 조회 (GET /api/v1/estimates)**
- ADMIN은 전체 조회, MEMBER는 본인 견적서만 조회
- List<EstimateResponseDto> 형태로 응답 데이터 제공

[Response body]
```
[
    {
        "id": 7,
        "title": "견적서 테스트2",
        "content": "견적서 테스트2",
        "createdAt": "2025-02-25T20:18:20.483726",
        "memberId": 5
    },
    {
        "id": 8,
        "title": "견적서 테스트333...",
        "content": "견적서 테스트3333333333333333333333",
        "createdAt": "2025-02-25T20:18:29.841911",
        "memberId": 5
    },
    {
        "id": 9,
        "title": "견적서 444444...",
        "content": "견적서 44444444444444444444444",
        "createdAt": "2025-02-25T20:20:31.883774",
        "memberId": 5
    }
]
```

## 📝 상세 내용
**1. 견적서(Estimate) 엔티티 개발**
- id(PK), title, content, createdAt 필드 추가
- Member 엔티티와 OneToMany 관계 설정 (member_id를 외래 키로 사용)
- title은 content 앞 10글자를 기반으로 자동 생성 (10글자 이상이면 "..." 추가)

**2. 견적서 생성 기능 (POST /api/v1/estimates)**
- 인증된 사용자만 견적서 생성 가능
- SecurityContextHolder에서 현재 로그인된 사용자(Member) 정보를 가져와 Estimate 생성
- 생성된 견적서 정보를 EstimateResponseDto로 반환

**3. 견적서 조회 기능 (GET /api/v1/estimates)**
- Member와 Estimate를 OneToMany로 연결하여 사용자의 견적서를 조회
- 사용자(MEMBER)는 자신의 견적서만 조회 가능
- 관리자(ADMIN) 권한이 있으면 모든 견적서 조회 가능

**4. Member - Estimate 연관 관계 설정**
- Member 엔티티에 List<Estimate> 필드 추가 (@OneToMany(mappedBy = "member"))
- CascadeType.ALL 설정하여 Member 삭제 시 견적서도 삭제되도록 처리
- fetch = FetchType.LAZY 설정하여 성능 최적화

**5. JWT 기반 인증 보완**
- JwtProvider에서 Member 객체를 직접 Authentication에 포함하도록 변경
- SecurityConfig에서 requestMatchers("/api/v1/estimates/**").hasAnyRole("MEMBER", "ADMIN") 설정

**6. 견적서 컨트롤러, 서비스, 레포지토리 테스트 코드 작성**
- 테스트 환경 실행 파일 사용 (H2 인메모리 DB 사용)
- 컨트롤러 테스트: 견적서 생성 및 조회 API, 사용자 인증 테스트
- 서비스 테스트: 견적서 생성 및 조회, 견적서 내용이 비어있는 경우 예외 처리, 인증되지 않은 사용자가 견적서 조회 시 예외 처리
- 레포지토리 테스트: 견적서 저장 및 조회 , 견적서 사용자 ID로 조회, 존재하지 않는 견적서 조회 시 빈값 반환, 견적서 삭제

## 📍추후 개선사항
- UserDetails 커스텀 적용하여 필요한 정보(username, id)만 추출해서 SecurityContext에 저장하고, 비밀번호와 같은 민감한 정보는 추출하지 못하도록 보안 강화
- 견적서 수정 및 삭제 API 구현

## ✔️추가 변경사항
**소나클라우드 비활성화**
- 현재 소나클라우드에서 JaCoCo를 도입하지 않아 테스트 커버리지를 측정하지 못함
- 테스트 코드 커버리지 측정을 위해 JaCoCo를 도입하였지만 지속적인 오류로 추후 해결 및 재도입 고려
- 소나클라우드의 무료 요금제가 변경되면서 main 브랜치만 결과를 알려주는 문제 발생
