### PR TITLE
[Feat] 아이디 찾기 및 비밀번호 재설정 기능 구현

### DIFF
--- a/backend/src/main/java/com/postdm/backend/domain/auth/api/AuthController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/api/AuthController.java
@@ -6,6 +6,10 @@ import com.postdm.backend.domain.auth.dto.SignInRequestDto;
 import com.postdm.backend.domain.auth.dto.SignUpRequestDto;
 import com.postdm.backend.domain.member.domain.entity.Member;
 import com.postdm.backend.global.template.ResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Auth API", description = "회원가입 및 로그인 API")
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthController { // 로그인 및 회원 가입 컨트롤러
@@ -22,12 +27,20 @@ public class AuthController { // 로그인 및 회원 가입 컨트롤러
     @Autowired
     private AuthService authService;
 
+    @Operation(summary = "아이디 중복 확인 컨트롤러")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/id-check") // 아이디 중복 확인 요청
     public ResponseTemplate<String> idCheck(@RequestBody IdCheckRequestDto idCheckRequestDto) {
         String username = authService.idCheck(idCheckRequestDto.getUsername());
         return new ResponseTemplate<>(HttpStatus.OK, "사용할 수 있는 아이디 입니다.", username);
     }
 
+    @Operation(summary = "회원가입 컨트롤러")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/sign-up") // 회원 가입 요청
     public ResponseTemplate<Member> signUp(@RequestBody @Valid SignUpRequestDto signUpRequestDto) {
         Member member = authService.signUp(signUpRequestDto);
@@ -35,10 +48,15 @@ public class AuthController { // 로그인 및 회원 가입 컨트롤러
         return new ResponseTemplate<>(HttpStatus.OK, "회원가입 성공", member);
     }
 
+    @Operation(summary = "로그인 컨트롤러")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/sign-in") // 로그인 요청
     public ResponseTemplate<String> signIn(@RequestBody @Valid SignInRequestDto signInRequestDto, HttpServletResponse response) {
         String token = authService.signIn(signInRequestDto, response);
 
         return new ResponseTemplate<>(HttpStatus.OK, "로그인 성공", token);
     }
+
 }

--- a/backend/src/main/java/com/postdm/backend/domain/auth/dto/IdCheckRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/dto/IdCheckRequestDto.java
@@ -1,5 +1,6 @@
 package com.postdm.backend.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
+@Schema(description = "아이디 중복확인 DTO")
 @NoArgsConstructor
 public class IdCheckRequestDto { // 아이디 중복 확인 데이터 전송을 위한 DTO
 

--- a/backend/src/main/java/com/postdm/backend/domain/auth/dto/SignInRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/dto/SignInRequestDto.java
@@ -1,7 +1,9 @@
 package com.postdm.backend.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+@Schema(description = "로그인 DTO")
 @Data
 public class SignInRequestDto { // 로그인 데이터 전송을 위한 DTO
 

--- a/backend/src/main/java/com/postdm/backend/domain/auth/dto/SignUpRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/dto/SignUpRequestDto.java
@@ -16,6 +16,7 @@ public class SignUpRequestDto { // 회원가입 데이터 전송을 위한 DTO
     private String nickname;
 
     @NotBlank
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]{7,15}$") // 영문자, 숫자를 포함한 7글자 이상 15글자 이하
     private String username;
 
     @NotBlank

--- a/backend/src/main/java/com/postdm/backend/domain/auth/dto/SignUpRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/dto/SignUpRequestDto.java
@@ -1,5 +1,6 @@
 package com.postdm.backend.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -7,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Schema(description = "회원가입 DTO")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/src/main/java/com/postdm/backend/domain/email/api/EmailController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/email/api/EmailController.java
@@ -25,4 +25,11 @@ public class EmailController { // 이메일 관련 컨트롤러
 
         return new ResponseTemplate<>(HttpStatus.OK, "이메일이 성공적으로 발송되었습니다.", certificationEntity);
     }
+
+    @PostMapping("/reset-certification")
+    public ResponseTemplate<CertificationEntity> resetCertification(@RequestBody @Valid EmailCertificationRequestDto emailCertificationRequestDto) {
+        CertificationEntity certificationEntity = emailService.resetCertification(emailCertificationRequestDto);
+
+        return new ResponseTemplate<>(HttpStatus.OK, "이메일이 성공적으로 발송되었습니다.", certificationEntity);
+    }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/email/api/EmailController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/email/api/EmailController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1/email")
 public class EmailController { // 이메일 관련 컨트롤러
 
     @Autowired

--- a/backend/src/main/java/com/postdm/backend/domain/email/api/EmailController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/email/api/EmailController.java
@@ -4,6 +4,9 @@ import com.postdm.backend.domain.email.application.EmailService;
 import com.postdm.backend.domain.email.domain.entity.CertificationEntity;
 import com.postdm.backend.domain.email.dto.EmailCertificationRequestDto;
 import com.postdm.backend.global.template.ResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -19,6 +22,10 @@ public class EmailController { // 이메일 관련 컨트롤러
     @Autowired
     private EmailService emailService;
 
+    @Operation(summary = "회원가입용 이메일 전송 컨트롤러")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/email-certification") // 이메일 전송 요청 api
     public ResponseTemplate<CertificationEntity> emailCertification(@RequestBody @Valid EmailCertificationRequestDto emailCertificationRequestDto) {
         CertificationEntity certificationEntity = emailService.emailCertification(emailCertificationRequestDto);
@@ -26,6 +33,10 @@ public class EmailController { // 이메일 관련 컨트롤러
         return new ResponseTemplate<>(HttpStatus.OK, "이메일이 성공적으로 발송되었습니다.", certificationEntity);
     }
 
+    @Operation(summary = "비밀번호 재설정용 이메일 전송 컨트롤러")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/reset-certification")
     public ResponseTemplate<CertificationEntity> resetCertification(@RequestBody @Valid EmailCertificationRequestDto emailCertificationRequestDto) {
         CertificationEntity certificationEntity = emailService.resetCertification(emailCertificationRequestDto);

--- a/backend/src/main/java/com/postdm/backend/domain/email/application/EmailService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/email/application/EmailService.java
@@ -41,4 +41,15 @@ public class EmailService { // 이메일 관련 서비스
 
         return certificationRepository.save(certificationEntity);
     }
+
+    public CertificationEntity resetCertification(EmailCertificationRequestDto emailCertificationRequestDto) {
+        String username = emailCertificationRequestDto.getUsername();
+        String email = emailCertificationRequestDto.getEmail();
+
+        String certificationNumber = CertificationNumber.getCertificationNumber();
+        emailProvider.sendCertificationMail(email, certificationNumber);
+
+        CertificationEntity certificationEntity = new CertificationEntity(username, email, bCryptPasswordEncoder.encode(certificationNumber));
+        return certificationRepository.save(certificationEntity);
+    }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/email/dto/CheckCertificationRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/email/dto/CheckCertificationRequestDto.java
@@ -1,9 +1,11 @@
 package com.postdm.backend.domain.email.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
+@Schema(description = "인증번호 확인 DTO")
 @Data
 public class CheckCertificationRequestDto {
 

--- a/backend/src/main/java/com/postdm/backend/domain/email/dto/CheckCertificationRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/email/dto/CheckCertificationRequestDto.java
@@ -1,0 +1,19 @@
+package com.postdm.backend.domain.email.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class CheckCertificationRequestDto {
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String certificationNumber;
+}

--- a/backend/src/main/java/com/postdm/backend/domain/email/dto/EmailCertificationRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/email/dto/EmailCertificationRequestDto.java
@@ -1,11 +1,13 @@
 package com.postdm.backend.domain.email.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Schema(description = "이메일 인증 DTO")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/src/main/java/com/postdm/backend/domain/member/api/MemberController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/api/MemberController.java
@@ -1,0 +1,50 @@
+package com.postdm.backend.domain.member.api;
+
+import com.postdm.backend.domain.email.dto.CheckCertificationRequestDto;
+import com.postdm.backend.domain.member.application.MemberService;
+import com.postdm.backend.domain.member.domain.entity.Member;
+import com.postdm.backend.domain.member.dto.FindUsernameRequestDto;
+import com.postdm.backend.domain.member.dto.ResetPasswordRequestDto;
+import com.postdm.backend.global.template.ResponseTemplate;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PostMapping("/find-userId")
+    public ResponseTemplate<String> findUsername(@RequestBody @Valid FindUsernameRequestDto findUsernameRequestDto) {
+        Member member = memberService.findUsernameByEmail(findUsernameRequestDto);
+
+        String username = member.getUsername();
+
+        String blurred = member.makeBlur(username);
+
+        return new ResponseTemplate<>(HttpStatus.OK, "아이디 찾기 성공", blurred);
+    }
+
+    @PostMapping("/check-certification")
+    public ResponseTemplate<String> checkCertificationNumber(@RequestBody @Valid CheckCertificationRequestDto checkCertificationRequestDto) {
+        String success =  memberService.checkCertificationNumber(checkCertificationRequestDto);
+
+        return new ResponseTemplate<>(HttpStatus.OK, success, "****");
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseTemplate<String> resetPassword(@RequestBody @Valid ResetPasswordRequestDto requestDto) {
+        String success = memberService.resetPassword(requestDto);
+
+        return new ResponseTemplate<>(HttpStatus.OK, success, "****");
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/domain/member/api/MemberController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/api/MemberController.java
@@ -46,10 +46,10 @@ public class MemberController {
             @ApiResponse(responseCode = "200", description = "성공"),
     })
     @PostMapping("/check-certification")
-    public ResponseTemplate<String> checkCertificationNumber(@RequestBody @Valid CheckCertificationRequestDto checkCertificationRequestDto) {
-        String success =  memberService.checkCertificationNumber(checkCertificationRequestDto);
+    public ResponseTemplate<Boolean> checkCertificationNumber(@RequestBody @Valid CheckCertificationRequestDto checkCertificationRequestDto) {
+        boolean success =  memberService.checkCertificationNumber(checkCertificationRequestDto);
 
-        return new ResponseTemplate<>(HttpStatus.OK, success, "****");
+        return new ResponseTemplate<>(HttpStatus.OK, "이메일 인증 성공", success);
     }
 
     @Operation(summary = "비밀번호 재설정 컨트롤러")
@@ -57,9 +57,9 @@ public class MemberController {
             @ApiResponse(responseCode = "200", description = "성공"),
     })
     @PostMapping("/reset-password")
-    public ResponseTemplate<String> resetPassword(@RequestBody @Valid ResetPasswordRequestDto requestDto) {
-        String success = memberService.resetPassword(requestDto);
+    public ResponseTemplate<Member> resetPassword(@RequestBody @Valid ResetPasswordRequestDto requestDto) {
+        Member member = memberService.resetPassword(requestDto);
 
-        return new ResponseTemplate<>(HttpStatus.OK, success, "****");
+        return new ResponseTemplate<>(HttpStatus.OK, "비밀번호 변경 성공", member);
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/member/api/MemberController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/api/MemberController.java
@@ -6,6 +6,9 @@ import com.postdm.backend.domain.member.domain.entity.Member;
 import com.postdm.backend.domain.member.dto.FindUsernameRequestDto;
 import com.postdm.backend.domain.member.dto.ResetPasswordRequestDto;
 import com.postdm.backend.global.template.ResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,6 +26,10 @@ public class MemberController {
         this.memberService = memberService;
     }
 
+    @Operation(summary = "아이디 찾기 컨트롤러")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/find-userId")
     public ResponseTemplate<String> findUsername(@RequestBody @Valid FindUsernameRequestDto findUsernameRequestDto) {
         Member member = memberService.findUsernameByEmail(findUsernameRequestDto);
@@ -34,6 +41,10 @@ public class MemberController {
         return new ResponseTemplate<>(HttpStatus.OK, "아이디 찾기 성공", blurred);
     }
 
+    @Operation(summary = "비밀번호 재설정 이메일 인증 확인 컨트롤러")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/check-certification")
     public ResponseTemplate<String> checkCertificationNumber(@RequestBody @Valid CheckCertificationRequestDto checkCertificationRequestDto) {
         String success =  memberService.checkCertificationNumber(checkCertificationRequestDto);
@@ -41,6 +52,10 @@ public class MemberController {
         return new ResponseTemplate<>(HttpStatus.OK, success, "****");
     }
 
+    @Operation(summary = "비밀번호 재설정 컨트롤러")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/reset-password")
     public ResponseTemplate<String> resetPassword(@RequestBody @Valid ResetPasswordRequestDto requestDto) {
         String success = memberService.resetPassword(requestDto);

--- a/backend/src/main/java/com/postdm/backend/domain/member/application/MemberService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/application/MemberService.java
@@ -35,7 +35,7 @@ public class MemberService {
         return member;
     }
 
-    public String checkCertificationNumber(CheckCertificationRequestDto checkCertificationRequestDto) {
+    public boolean checkCertificationNumber(CheckCertificationRequestDto checkCertificationRequestDto) {
         String username  = checkCertificationRequestDto.getUsername();
         String email = checkCertificationRequestDto.getEmail();
         String certificationNumber = checkCertificationRequestDto.getCertificationNumber();
@@ -54,10 +54,10 @@ public class MemberService {
             throw new IllegalArgumentException();
         }
 
-        return "인증 성공";
+        return true;
     }
 
-    public String resetPassword(ResetPasswordRequestDto resetPasswordRequestDto) {
+    public Member resetPassword(ResetPasswordRequestDto resetPasswordRequestDto) {
         String username =  resetPasswordRequestDto.getUsername();
         String password = resetPasswordRequestDto.getPassword();
         String confirmPassword = resetPasswordRequestDto.getConfirmPassword();
@@ -79,6 +79,6 @@ public class MemberService {
         memberRepository.save(member);
         certificationRepository.delete(certificationEntity);
 
-        return "비밀번호 변경 성공";
+        return member;
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/member/application/MemberService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/application/MemberService.java
@@ -1,0 +1,84 @@
+package com.postdm.backend.domain.member.application;
+
+import com.postdm.backend.domain.email.domain.entity.CertificationEntity;
+import com.postdm.backend.domain.email.domain.repository.CertificationRepository;
+import com.postdm.backend.domain.email.dto.CheckCertificationRequestDto;
+import com.postdm.backend.domain.member.dto.FindUsernameRequestDto;
+import com.postdm.backend.domain.member.domain.entity.Member;
+import com.postdm.backend.domain.member.domain.repository.MemberRepository;
+import com.postdm.backend.domain.member.dto.ResetPasswordRequestDto;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    private final CertificationRepository certificationRepository;
+
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public MemberService(MemberRepository memberRepository,  CertificationRepository certificationRepository,  BCryptPasswordEncoder bCryptPasswordEncoder) {
+        this.memberRepository = memberRepository;
+        this.certificationRepository = certificationRepository;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+    }
+
+    public Member findUsernameByEmail(FindUsernameRequestDto findUsernameRequestDto) {
+        Member member = memberRepository.findByEmail(findUsernameRequestDto.getEmail());
+
+        if(member == null) {
+            throw new IllegalArgumentException("존재하지 않는 메일 입니다.");
+        }
+
+        return member;
+    }
+
+    public String checkCertificationNumber(CheckCertificationRequestDto checkCertificationRequestDto) {
+        String username  = checkCertificationRequestDto.getUsername();
+        String email = checkCertificationRequestDto.getEmail();
+        String certificationNumber = checkCertificationRequestDto.getCertificationNumber();
+
+        CertificationEntity certificationEntity = certificationRepository.findByUsername(username);
+
+        if(certificationEntity == null) {
+            throw new IllegalArgumentException();
+        }
+
+        String encodedCertificationNumber = certificationEntity.getCertificationNumber();
+
+        boolean isMatched = certificationEntity.getEmail().equals(email) && bCryptPasswordEncoder.matches(certificationNumber, encodedCertificationNumber);
+
+        if(!isMatched) {
+            throw new IllegalArgumentException();
+        }
+
+        return "인증 성공";
+    }
+
+    public String resetPassword(ResetPasswordRequestDto resetPasswordRequestDto) {
+        String username =  resetPasswordRequestDto.getUsername();
+        String password = resetPasswordRequestDto.getPassword();
+        String confirmPassword = resetPasswordRequestDto.getConfirmPassword();
+
+        if(!password.equals(confirmPassword)) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String encodedPassword = bCryptPasswordEncoder.encode(password);
+
+        CertificationEntity certificationEntity = certificationRepository.findByUsername(username);
+        if(certificationEntity == null) {
+            throw new IllegalArgumentException();
+        }
+
+        Member member = memberRepository.findByUsername(username);
+        member.setPassword(encodedPassword);
+
+        memberRepository.save(member);
+        certificationRepository.delete(certificationEntity);
+
+        return "비밀번호 변경 성공";
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/domain/member/domain/entity/Member.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/domain/entity/Member.java
@@ -1,13 +1,11 @@
 package com.postdm.backend.domain.member.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -28,5 +26,13 @@ public class Member { // 사용자 엔티티
 
     @Enumerated(EnumType.STRING)
     private MemberRole role;
+
+    public String makeBlur(String username) {
+        String[] parts = username.split("");
+        for(int i = 3; i < parts.length - 1; i++) {
+            parts[i] = "*";
+        }
+        return String.join("", parts);
+    }
 
 }

--- a/backend/src/main/java/com/postdm/backend/domain/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/domain/repository/MemberRepository.java
@@ -9,4 +9,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
     boolean existsByUsername(String username);
     Member findByUsername(String username);
+    Member findByEmail(String email);
 }

--- a/backend/src/main/java/com/postdm/backend/domain/member/dto/FindUsernameRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/dto/FindUsernameRequestDto.java
@@ -1,10 +1,12 @@
 package com.postdm.backend.domain.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 import lombok.Data;
 
+@Schema(description = "아이디 찾기 DTO")
 @Data
 public class FindUsernameRequestDto {
 

--- a/backend/src/main/java/com/postdm/backend/domain/member/dto/FindUsernameRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/dto/FindUsernameRequestDto.java
@@ -1,0 +1,15 @@
+package com.postdm.backend.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Data;
+
+@Data
+public class FindUsernameRequestDto {
+
+    @NotBlank
+    @Email
+    private String email;
+
+}

--- a/backend/src/main/java/com/postdm/backend/domain/member/dto/ResetPasswordRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/dto/ResetPasswordRequestDto.java
@@ -1,8 +1,10 @@
 package com.postdm.backend.domain.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
+@Schema(description = "비밀번호 재설정 DTO")
 @Data
 public class ResetPasswordRequestDto {
 

--- a/backend/src/main/java/com/postdm/backend/domain/member/dto/ResetPasswordRequestDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/dto/ResetPasswordRequestDto.java
@@ -1,0 +1,18 @@
+package com.postdm.backend.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ResetPasswordRequestDto {
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    private String confirmPassword;
+
+}

--- a/backend/src/main/java/com/postdm/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/postdm/backend/global/config/SecurityConfig.java
@@ -40,6 +40,8 @@ public class SecurityConfig { // 시큐리티 설정을 위한 Config
         http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll() // /api/v1/auth로 시작하는 경로는 모두 허용(회원가입, 로그인 등)
+                        .requestMatchers("/api/v1/email/**").permitAll()
+                        .requestMatchers("/api/v1/member/**").permitAll()
                         .requestMatchers("/api/v1/estimates/**").hasAnyRole("MEMBER", "ADMIN") // 견적서 API는 MEMBER와 ADMIN만 접근 가능
                         .anyRequest().authenticated() // 이외의 경로는 인증을 필요로함.
                 );


### PR DESCRIPTION
## 📌 개요
- 사용자의 아이디 찾기 및 비밀번호 재설정 기능을 구현 완료했습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #24 

## ✅ 변경 사항
- 사용자의 아이디 찾기 및 비밀번호 재설정이 가능해졌습니다.
- 사용자의 아이디를 영문자 및 숫자 포함 최소 7글자 최대 15글자로 제한합니다.
- Swagger 문서에서 회원가입/로그인, 아이디 찾기/비밀번호 재설정 관련 api에 대한 설명을 추가했습니다.

## 📝 상세 내용
- 아이디 찾기
  - 사용자의 이메일을 입력하여 해당 사용자의 아이디를 반환합니다. 
- 비밀번호 재설정
  - 사용자의 아이디와 이메일 인증을 통해 비밀번호 재설정이 가능합니다.
  - 비밀번호 재설정은 변경 비밀번호와 변경 비밀번호 확인을 통해 이루어집니다.
