### PR TITLE
[Feat] 서버 연결 확인 API 및 헬스 체크 API 설정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'com.h2database:h2' //테스트 환경 h2 DB
 	testImplementation 'org.assertj:assertj-core:3.24.2' //테스트 검증을 위한 AssertJ 라이브러리
+
+	implementation 'org.springframework.boot:spring-boot-starter-actuator' // Actuator 기능으로 서버 및 애플리케이션 상태 확인
+	runtimeOnly 'mysql:mysql-connector-java:8.0.33'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/postdm/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/postdm/backend/global/config/SecurityConfig.java
@@ -49,6 +49,9 @@ public class SecurityConfig { // 시큐리티 설정을 위한 Config
                         .requestMatchers("/api/v1/auth/**").permitAll() // /api/v1/auth로 시작하는 경로는 모두 허용(회원가입, 로그인 등)
                         .requestMatchers("/api/v1/email/**").permitAll()
                         .requestMatchers("/api/v1/member/**").permitAll()
+                        .requestMatchers("/api/v1/ping**").permitAll() // /ping api 모두 허용
+                        .requestMatchers("/actuator/health").hasRole("ADMIN") // Actuator 헬스 체크 결과는 관리자만 접근 가능
+                        .requestMatchers("/actuator/**").denyAll() // 다른 Actuator 엔드포인트는 차단
                         .requestMatchers("/api/v1/estimates/**").hasAnyRole("MEMBER", "ADMIN") // 견적서 API는 MEMBER와 ADMIN만 접근 가능
                         .anyRequest().authenticated() // 이외의 경로는 인증을 필요로함.
                 );

--- a/backend/src/main/java/com/postdm/backend/global/controller/PingController.java
+++ b/backend/src/main/java/com/postdm/backend/global/controller/PingController.java
@@ -1,0 +1,25 @@
+package com.postdm.backend.global.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.Map;
+
+@RestController
+@Tag(name = "Ping Check", description = "단순 서버 연결 상태 확인 API")
+@RequestMapping("/api/v1")
+public class PingController {
+
+    @Operation(summary = "서버 상태 체크", description = "서버가 정상적으로 동작하는지 확인하는 API입니다.")
+    @ApiResponse(responseCode = "200", description = "서버 정상 작동. 응답: text/plain (pong)")
+    @GetMapping("/ping")
+    public ResponseEntity<Map<String, String>> ping() {
+        return ResponseEntity.ok(Collections.singletonMap("message", "pong"));
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -18,3 +18,8 @@ springdoc:
       enabled: true
   cache:
     disabled: true
+
+management:
+  endpoint:
+    health:
+      show-details: always

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,4 +22,4 @@ springdoc:
 management:
   endpoint:
     health:
-      show-details: always
+      show-details: when_authorized


### PR DESCRIPTION
## 📌 개요
- 클라이언트가 백엔드 서버 연결 상태를 확인할 수 있도록 /ping API 엔드포인트를 추가
- Actuator를 활용하여 서버 상태 및 다양한 헬스 체크 기능을 추가

## 🚀 관련 이슈
- 관련된 이슈 번호: #37 

## ✅ 변경 사항
- `/ping` 엔드포인트 추가:  클라이언트가 서버 연결 상태 확인 가능
- Spring Boot Actuator 설정 추가: `/actuator/health`에서 서버 및 DB 상태 등 확인 가
- Actuator 세부 정보 활성화: 보안을 위해 인증된 관리자만 모든 Actuator 헬스 체크 확인 가능

## 📝 상세 내용
**1. `/ping` 엔드포인트 추가**
- 서버 연결 확인 API: `GET /ping`
- 클라이언트가 서버 연결을 확인할 수 있도록 /ping API 추가
- Swagger 문서에서 테스트 가능
- 응답 예시 (`GET /ping` 호출 시)
```
{
  "message": "pong"
}
```
**2. `/actuator/health`**
- 헬스 체크 API: `GET /actuator/health`
- `/actuator/health` 엔드포인트에서 Actuator에서 기본 제공하는 서버, CPU, 메모리, DB 연결 상태, 디스크 상태 등 확인 가능
- 보안상 인증된 ADMIN 역할이 있는 사용자만 접근 가능하도록 Spring Security 설정 추가
- Postman에서 테스트 가능

## 🔍 테스트
- `/ping` 엔드포인트 테스트: 클라이언트에서 pong 응답 확인
- `/actuator/health` 테스트: 인증된 관리자만 서버 및 DB 상태 등 Actuator 헬스 체크 응답 확인
- 보안 테스트: 인증되지 않은 사용자가 `/actuator/health` 접근 시 `403 Forbidden` 반환

## 📸 스크린샷
![ping check](https://github.com/user-attachments/assets/b93cce24-ce5e-409e-b0cb-221219cd9221)

