### PR TITLE
[Feat] 로그아웃 API 구현

### DIFF
--- a/backend/src/main/java/com/postdm/backend/BackendApplication.java
+++ b/backend/src/main/java/com/postdm/backend/BackendApplication.java
@@ -2,12 +2,13 @@ package com.postdm.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling // 스케줄링 기능 활성화
 public class BackendApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(BackendApplication.class, args);
 	}
-
 }

--- a/backend/src/main/java/com/postdm/backend/domain/auth/api/AuthController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/api/AuthController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Auth API", description = "회원가입 및 로그인 API")
 @RestController
@@ -77,4 +78,15 @@ public class AuthController { // 로그인 및 회원 가입 컨트롤러
         return new ResponseTemplate<>(HttpStatus.OK, "로그인 성공", token);
     }
 
+    @Operation(summary = "로그아웃 컨트롤러", description = "로그아웃을 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
+    @PostMapping("/sign-out") // 로그아웃 요청
+    public ResponseTemplate<?> singOut(@RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring(7);
+        authService.signOut(token);
+
+        return new ResponseTemplate<>(HttpStatus.OK, "로그아웃 성공", token);
+    }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/auth/application/AuthService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/application/AuthService.java
@@ -25,6 +25,7 @@ public class AuthService { // 로그인 및 회원가입 서비스
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final JwtProvider jwtProvider;
     private final int refreshedMS;
+    private final TokenBlacklistService tokenBlacklistService;
 
     // 생성자 주입 방식
     public AuthService(
@@ -32,12 +33,14 @@ public class AuthService { // 로그인 및 회원가입 서비스
             CertificationRepository certificationRepository,
             BCryptPasswordEncoder bCryptPasswordEncoder,
             JwtProvider jwtProvider,
-            @Value("${jwt.expiredMS}") int refreshedMS) {
+            @Value("${jwt.expiredMS}") int refreshedMS,
+            TokenBlacklistService tokenBlacklistService) {
         this.memberRepository = memberRepository;
         this.certificationRepository = certificationRepository;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.jwtProvider = jwtProvider;
         this.refreshedMS = refreshedMS;
+        this.tokenBlacklistService = tokenBlacklistService;
     }
 
 
@@ -138,4 +141,12 @@ public class AuthService { // 로그인 및 회원가입 서비스
         return cookie;
     }
 
+    public void signOut(String accessToken) {
+        long expireMillis = jwtProvider.getExpiration(accessToken);
+        boolean isNewlySaved = tokenBlacklistService.saveIfNotExists(accessToken, expireMillis);
+
+        if (!isNewlySaved) {
+            throw new CustomException(ErrorCode.ALREADY_SIGN_OUT);
+        }
+    }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/auth/application/TokenBlacklistService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/application/TokenBlacklistService.java
@@ -1,0 +1,45 @@
+package com.postdm.backend.domain.auth.application;
+
+import com.postdm.backend.domain.auth.domain.TokenBlacklist;
+import com.postdm.backend.domain.auth.repository.TokenBlacklistRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private final TokenBlacklistRepository repository;
+
+    public void save(String token, long expireMillis) {
+        LocalDateTime expiration = LocalDateTime.now().plus(Duration.ofMillis(expireMillis));
+        repository.save(new TokenBlacklist(token, expiration));
+    }
+
+    public boolean isBlacklisted(String token) {
+        return repository.existsByToken(token);
+    }
+
+    // 중복 저장 방지
+    public boolean saveIfNotExists(String token, long expireMillis) {
+        if (repository.existsByToken(token)) {
+            return false; // 이미 블랙리스트에 있음
+        }
+
+        LocalDateTime expiration = LocalDateTime.now().plus(Duration.ofMillis(expireMillis));
+        repository.save(new TokenBlacklist(token, expiration));
+        return true;
+    }
+
+    // 만료된 토큰 정리
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul") // 매시 정각
+    @Transactional
+    public void cleanExpiredTokens() {
+        repository.deleteAllByExpirationBefore(LocalDateTime.now());
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/domain/auth/domain/TokenBlacklist.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/domain/TokenBlacklist.java
@@ -1,0 +1,28 @@
+package com.postdm.backend.domain.auth.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Entity
+@Table(name = "token_blacklist")
+public class TokenBlacklist {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Lob
+    private String token;
+
+    private LocalDateTime expiration;
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public TokenBlacklist(String token, LocalDateTime expiration) {
+        this.token = token;
+        this.expiration = expiration;
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/domain/auth/repository/TokenBlacklistRepository.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/repository/TokenBlacklistRepository.java
@@ -1,0 +1,11 @@
+package com.postdm.backend.domain.auth.repository;
+
+import com.postdm.backend.domain.auth.domain.TokenBlacklist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface TokenBlacklistRepository extends JpaRepository<TokenBlacklist, Long> {
+    boolean existsByToken(String token);
+    void deleteAllByExpirationBefore(LocalDateTime time);
+}

--- a/backend/src/main/java/com/postdm/backend/global/common/response/ErrorCode.java
+++ b/backend/src/main/java/com/postdm/backend/global/common/response/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
     NOT_MATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다"),
     SIGN_IN_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 잘못되었습니다."),
 
+    // 로그아웃 관련
+    ALREADY_SIGN_OUT(HttpStatus.BAD_REQUEST, "이미 로그아웃된 토큰입니다."),
+
     // 아이디 찾기 및 비밀번호 재설정 관련
     NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "존재하지 않는 이메일 입니다."),
 

--- a/backend/src/main/java/com/postdm/backend/global/common/response/ErrorCode.java
+++ b/backend/src/main/java/com/postdm/backend/global/common/response/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
     SIGN_IN_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 잘못되었습니다."),
 
     // 로그아웃 관련
-    ALREADY_SIGN_OUT(HttpStatus.BAD_REQUEST, "이미 로그아웃된 토큰입니다."),
+    ALREADY_SIGN_OUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃된 토큰입니다."),
 
     // 아이디 찾기 및 비밀번호 재설정 관련
     NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "존재하지 않는 이메일 입니다."),

--- a/backend/src/main/java/com/postdm/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/postdm/backend/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.postdm.backend.global.config;
 
 import com.postdm.backend.global.jwt.filter.JwtAuthenticationFilter;
 import com.postdm.backend.global.jwt.util.JwtProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,11 +21,14 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.List;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig { // 시큐리티 설정을 위한 Config
 
-    @Autowired
-    private JwtProvider jwtProvider;
+//    @Autowired
+//    private JwtProvider jwtProvider;
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -60,7 +64,7 @@ public class SecurityConfig { // 시큐리티 설정을 위한 Config
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)); // 세션 비활성화
 
         http
-                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class); // JWT 토큰 필터
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class); // JWT 토큰 필터
 
 
         return http.build();

--- a/backend/src/main/java/com/postdm/backend/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/postdm/backend/global/jwt/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,10 @@
 package com.postdm.backend.global.jwt.filter;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.postdm.backend.domain.auth.application.TokenBlacklistService;
+import com.postdm.backend.global.common.response.ErrorCode;
+import com.postdm.backend.global.common.response.ErrorResponse;
 import com.postdm.backend.global.jwt.util.JwtProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -21,6 +25,8 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter { // JWT 필터. 해당 필터를 통해 JWT가 유효한지 판단
 
     private final JwtProvider jwtProvider;
+    private final TokenBlacklistService tokenBlacklistService;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -28,6 +34,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter { // JWT 필�
         String token = resolveToken(request);
 
         if (token != null && jwtProvider.validateToken(token)) {
+            // 블랙리스트에 있는지 확인
+            if (tokenBlacklistService.isBlacklisted(token)) {
+                log.warn("로그아웃된 토큰으로 접근 시도됨: {}", token);
+
+                ErrorCode errorCode = ErrorCode.ALREADY_SIGN_OUT;
+                ErrorResponse errorResponse = new ErrorResponse(errorCode);
+
+                response.setStatus(errorCode.getHttpStatus().value());
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+                return;
+            }
+
             Authentication auth = jwtProvider.getAuthentication(token); // 사용자 추출
             SecurityContextHolder.getContext().setAuthentication(auth); // SecurityContextHolder에 사용자 등록
         }

--- a/backend/src/main/java/com/postdm/backend/global/jwt/util/JwtProvider.java
+++ b/backend/src/main/java/com/postdm/backend/global/jwt/util/JwtProvider.java
@@ -118,4 +118,16 @@ public class JwtProvider { // JWT 발급을 위한 Provider
         // Spring Security에서 Authentication 객체의 principal을 Member 객체로 저장
         return new UsernamePasswordAuthenticationToken(member, "", authorities);
     }
+
+    // JWT 토큰 만료 시간 반환
+    public long getExpiration(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        Date expiration = claims.getExpiration();
+        return expiration.getTime() - System.currentTimeMillis();
+    }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: backend
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:prod}
+    active: ${SPRING_PROFILES_ACTIVE:dev}
     
 # Swagger 설정
 springdoc:

--- a/backend/src/test/java/com/postdm/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/postdm/backend/BackendApplicationTests.java
@@ -5,7 +5,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
 class BackendApplicationTests {
 
 	@Test

--- a/backend/src/test/java/com/postdm/backend/domain/estimate/integration/LogoutIntegrationTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/estimate/integration/LogoutIntegrationTest.java
@@ -60,7 +60,7 @@ class LogoutIntegrationTest {
         // 테스트용 사용자 등록
         Member member = Member.builder()
                 .username("홍길동")
-                .password(encodedPassword) // 실제 서비스에서 bcrypt 처리 필요
+                .password(encodedPassword)
                 .email("test@test.com")
                 .role(MemberRole.MEMBER)
                 .build();

--- a/backend/src/test/java/com/postdm/backend/domain/estimate/integration/LogoutIntegrationTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/estimate/integration/LogoutIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.postdm.backend.domain.estimate.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.postdm.backend.domain.auth.dto.SignInRequestDto;
+import com.postdm.backend.domain.auth.repository.TokenBlacklistRepository;
+import com.postdm.backend.domain.member.domain.entity.Member;
+import com.postdm.backend.domain.member.domain.entity.MemberRole;
+import com.postdm.backend.domain.member.domain.repository.MemberRepository;
+import com.postdm.backend.global.jwt.dto.TokenInfo;
+import com.postdm.backend.global.jwt.util.JwtProvider;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+class LogoutIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private TokenBlacklistRepository tokenBlacklistRepository;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    private String accessToken;
+
+
+    @BeforeEach
+    void setUp() {
+        String rawPassword = "testpassword1!";
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+
+        // 테스트용 사용자 등록
+        Member member = Member.builder()
+                .username("홍길동")
+                .password(encodedPassword) // 실제 서비스에서 bcrypt 처리 필요
+                .email("test@test.com")
+                .role(MemberRole.MEMBER)
+                .build();
+
+        memberRepository.save(member);
+
+        TokenInfo tokenInfo = jwtProvider.generateToken("홍길동", "MEMBER");
+        accessToken = tokenInfo.getAccessToken();
+    }
+
+    @Test
+    void 로그아웃_후_보호된_API_접근시_차단되어야_한다() throws Exception {
+        // 로그아웃 요청
+        mockMvc.perform(post("/api/v1/auth/sign-out")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
+
+        // 블랙리스트에 토큰 확인
+        boolean exists = tokenBlacklistRepository.existsByToken(accessToken);
+        assertTrue(exists, "토큰이 블랙리스트에 있어야 합니다.");
+
+        // 보호된 API 호출 실패
+        mockMvc.perform(get("/api/v1/estimates")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("이미 로그아웃된 토큰입니다."));
+    }
+}
+


### PR DESCRIPTION
## 📌 개요
- JWT 기반 로그아웃 API를 구현하여 Access Token을 블랙리스트에 등록해 무효화할 수 있도록 했습니다.
- 로그아웃된 토큰이 재사용되지 않도록 인증 필터에 블랙리스트 확인 로직을 추가하였고, 이 흐름을 검증하는 통합 테스트도 작성했습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #47 

## ✅ 변경 사항
- 로그아웃 API 추가
![image](https://github.com/user-attachments/assets/06933a41-c522-415d-9c20-3b43ce2dc170)

### 로그아웃 API Swagger 테스트 방법
1. 로그인 API (`/api/v1/auth/sign-in`) 호출 → Access Token 발급
2. 상단 `Authorize` 버튼 클릭 → 발급 받은 Access Token 넣기
3. 로그아웃 API (`/api/v1/auth/sign-out`) 테스트 → 발급 받은 Access Token 넣기
  - 성공 시 응답
```json
{
  "status": 200,
  "message": "로그아웃 성공",
  "data": "로그아웃한 Access Token"
}

```
  - 같은 토큰으로 보호된 API 호출 시 응답
```json
{
  "timestamp": "2025-04-11T17:24:11.5578222",
  "status": 401,
  "message": "이미 로그아웃된 토큰입니다."
}
```

## 📝 상세 내용
### 로그아웃 API 구현
- POST `/api/v1/auth/sign-out` 엔드포인트 추가
- Authorization 헤더에서 Access Token을 추출하여 로그아웃 처리
- Access Token을 token_blacklist 테이블에 저장하여 재사용 차단

### JWT 인증 필터 수정
- JwtAuthenticationFilter에 블랙리스트 확인 로직 추가
- 블랙리스트에 등록된 토큰으로 접근 시 `401 Unauthorized + "이미 로그아웃된 토큰입니다."` 반환

### 스케줄러 설정
- 만료된 블랙리스트 토큰을 매시 정각마다 주기적으로 삭제하는 `@Scheduled` 메서드 추가

### 공통 응답 적용
- 성공 시: SuccessResponse 사용 (status, message, data)
- 실패 시: `ErrorCode.ALREADY_SIGN_OUT` 기반 ErrorResponse 반환

### 로그아웃 API 통합 테스트 (LogoutIntegrationTest)
- 유저 등록 → 토큰 발급 → 로그아웃 → 보호된 API 접근 시 차단까지의 전체 흐름 검증
- 실제 서버를 띄우지 않고도 Controller를 HTTP처럼 테스트할 수 있는 MockMvc와 jwtProvider를 활용하여 실제 보안 흐름과 동일하게 테스트 구성