### PR TITLE
[feat] 로그아웃 API 연동

### DIFF
--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -6,6 +6,9 @@ import SignupInputField from "@/components/signup/SignupInputField";
 import PrivacyAgreement from "@/components/signup/PrivacyAgreement";
 import PrimaryButton from "@/components/find/PrimaryButton";
 import Title from "@/components/Title";
+import { useRouter } from "next/navigation";
+import { AnimatePresence, motion } from "framer-motion";
+import confetti from "canvas-confetti";
 
 const Signup = () => {
   const [username, setUsername] = useState("");
@@ -29,14 +32,25 @@ const Signup = () => {
     boolean | null
   >(null);
   const [isPrivacyChecked, setIsPrivacyChecked] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+
+  const router = useRouter();
+
+  const fireConfetti = () => {
+    confetti({
+      particleCount: 200,
+      spread: 120,
+      origin: { y: 0.6 },
+      scalar: 0.8,
+      colors: ["#A3C4F3", "#FFB6B9", "#FFDAC1", "#E2F0CB", "#B5EAD7"],
+    });
+  };
 
   const handleCheckUsername = async () => {
     try {
       const res = await axios.post("/api/v1/auth/id-check", { username });
-      console.log("중복 확인 응답:", res.data);
       setIsUsernameAvailable(res.data.status === 200);
-    } catch (error) {
-      console.error("Username check failed", error);
+    } catch {
       setIsUsernameAvailable(false);
     }
   };
@@ -66,8 +80,7 @@ const Signup = () => {
         setIsEmailAvailable(false);
         alert(res.data.message || "이메일 인증 요청 실패");
       }
-    } catch (error) {
-      console.error("Email verification request failed", error);
+    } catch {
       setIsEmailAvailable(false);
     }
   };
@@ -80,8 +93,7 @@ const Signup = () => {
         certificationNumber: verificationCode,
       });
       setIsVerificationSuccess(res.data.status === 200);
-    } catch (error) {
-      console.error("Verification failed", error);
+    } catch {
       setIsVerificationSuccess(false);
     }
   };
@@ -98,12 +110,16 @@ const Signup = () => {
         certificationNumber: verificationCode,
       });
       if (res.data.status === 200) {
-        alert("회원가입 완료");
+        setShowModal(true);
+        fireConfetti();
+        setTimeout(() => {
+          setShowModal(false);
+          router.push("/login");
+        }, 2000);
       } else {
         alert(res.data.message || "회원가입 실패");
       }
-    } catch (error) {
-      console.error("Signup error", error);
+    } catch {
       alert("회원가입 중 오류가 발생했습니다");
     }
   };
@@ -122,7 +138,7 @@ const Signup = () => {
     !isVerificationSuccess;
 
   return (
-    <div className="max-w-md mx-auto p-6 pt-[164px]">
+    <div className="max-w-md mx-auto p-6 pt-[164px] relative overflow-hidden">
       <Title pageTitle="회원가입" />
 
       <SignupInputField
@@ -218,6 +234,29 @@ const Signup = () => {
         onClick={handleSignup}
         disabled={isSignupDisabled}
       />
+
+      <AnimatePresence>
+        {showModal && (
+          <motion.div
+            className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <motion.div
+              className="bg-white p-6 rounded-lg shadow-lg text-center"
+              initial={{ scale: 0.8, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.8, opacity: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <p className="text-lg font-semibold">
+                회원가입이 완료되었습니다!
+              </p>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -48,7 +48,7 @@ const Header = () => {
   return (
     <>
       <header className="fixed top-0 left-0 right-0 h-[100px] flex items-center px-5 bg-white z-50">
-        <Link href="/home" className="flex items-center">
+        <Link href="/" className="flex items-center">
           <div className="relative w-[42px] h-[40px]">
             <Image
               src="/images/logo.svg"
@@ -133,16 +133,13 @@ const Header = () => {
             <nav className="px-5 mt-5">
               <ul className="divide-y divide-gray-200">
                 <li className="py-4">
-                  <Link
-                    href="/home"
-                    className="block w-full text-sm font-medium"
-                  >
+                  <Link href="/" className="block w-full text-sm font-medium">
                     홈
                   </Link>
                 </li>
                 <li className="py-4">
                   <Link
-                    href="/company"
+                    href="/about"
                     className="block w-full text-sm font-medium"
                   >
                     회사 소개

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,9 +5,11 @@ import Image from "next/image";
 import Link from "next/link";
 import axios from "@/utils/axios";
 import { useRouter } from "next/navigation";
+import { motion, AnimatePresence } from "framer-motion";
 
 const Header = () => {
   const [isNavOpen, setIsNavOpen] = useState(false);
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
   const router = useRouter();
 
   const toggleNav = () => {
@@ -28,7 +30,11 @@ const Header = () => {
       );
       localStorage.removeItem("accessToken");
       localStorage.removeItem("userRole");
-      router.push("/login");
+      setShowLogoutModal(true);
+      setTimeout(() => {
+        setShowLogoutModal(false);
+        router.push("/login");
+      }, 1500);
     } catch (err) {
       console.error("로그아웃 실패:", err);
     }
@@ -174,6 +180,27 @@ const Header = () => {
           </div>
         </div>
       )}
+
+      <AnimatePresence>
+        {showLogoutModal && (
+          <motion.div
+            className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-[80]"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <motion.div
+              className="bg-white px-6 py-4 rounded-lg shadow-lg text-center"
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <p className="text-lg font-semibold">로그아웃되었습니다.</p>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 };

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,34 +1,53 @@
-// src/components/Header.tsx
-'use client';
+"use client";
 
-import React, { useState } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
+import React, { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import axios from "@/utils/axios";
+import { useRouter } from "next/navigation";
 
 const Header = () => {
   const [isNavOpen, setIsNavOpen] = useState(false);
+  const router = useRouter();
 
   const toggleNav = () => {
     setIsNavOpen(!isNavOpen);
   };
 
-  // Prevent scrolling when nav is open
+  const handleLogout = async () => {
+    try {
+      const accessToken = localStorage.getItem("accessToken");
+      await axios.post(
+        "/api/v1/auth/sign-out",
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      );
+      localStorage.removeItem("accessToken");
+      localStorage.removeItem("userRole");
+      router.push("/login");
+    } catch (err) {
+      console.error("로그아웃 실패:", err);
+    }
+  };
+
   React.useEffect(() => {
     if (isNavOpen) {
-      document.body.style.overflow = 'hidden';
+      document.body.style.overflow = "hidden";
     } else {
-      document.body.style.overflow = 'auto';
+      document.body.style.overflow = "auto";
     }
-    
     return () => {
-      document.body.style.overflow = 'auto';
+      document.body.style.overflow = "auto";
     };
   }, [isNavOpen]);
 
   return (
     <>
       <header className="fixed top-0 left-0 right-0 h-[100px] flex items-center px-5 bg-white z-50">
-        {/* Logo with Link to Home */}
         <Link href="/home" className="flex items-center">
           <div className="relative w-[42px] h-[40px]">
             <Image
@@ -39,8 +58,6 @@ const Header = () => {
               priority
             />
           </div>
-          
-          {/* POSTDM */}
           <div className="relative ml-[15px]">
             <Image
               src="/images/POSTDM.svg"
@@ -49,17 +66,16 @@ const Header = () => {
               height={24}
               className="object-contain"
               style={{
-                fontFamily: 'Impact',
-                fontSize: '20px',
-                lineHeight: '24px',
+                fontFamily: "Impact",
+                fontSize: "20px",
+                lineHeight: "24px",
                 fontWeight: 400,
               }}
             />
           </div>
         </Link>
-        
-        {/* Navigation Button */}
-        <button 
+
+        <button
           className="relative w-[22px] h-[20px] ml-auto flex items-center justify-center"
           aria-label="Toggle navigation"
           onClick={toggleNav}
@@ -74,55 +90,87 @@ const Header = () => {
         </button>
       </header>
 
-      {/* Navigation Overlay - 높은 z-index로 Title까지 가리도록 설정 */}
       {isNavOpen && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 z-[60]" onClick={toggleNav}>
-          {/* Navigation Menu */}
-          <div 
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 z-[60]"
+          onClick={toggleNav}
+        >
+          <div
             className="absolute right-0 top-0 h-full w-3/5 max-w-[220px] bg-white z-[70]"
-            onClick={(e) => e.stopPropagation()} // Prevent clicks inside from closing
+            onClick={(e) => e.stopPropagation()}
           >
-            {/* Close button */}
             <div className="flex justify-end p-5">
-              <button 
+              <button
                 onClick={toggleNav}
                 className="p-2"
                 aria-label="Close navigation"
               >
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M18 6L6 18" stroke="black" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                  <path d="M6 6L18 18" stroke="black" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M18 6L6 18"
+                    stroke="black"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M6 6L18 18"
+                    stroke="black"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
                 </svg>
               </button>
             </div>
 
-            {/* Navigation Items */}
             <nav className="px-5 mt-5">
               <ul className="divide-y divide-gray-200">
                 <li className="py-4">
-                  <Link href="/home" className="block w-full text-sm font-medium">
+                  <Link
+                    href="/home"
+                    className="block w-full text-sm font-medium"
+                  >
                     홈
                   </Link>
                 </li>
                 <li className="py-4">
-                  <Link href="/company" className="block w-full text-sm font-medium">
+                  <Link
+                    href="/company"
+                    className="block w-full text-sm font-medium"
+                  >
                     회사 소개
                   </Link>
                 </li>
                 <li className="py-4">
-                  <Link href="/estimate/list" className="block w-full text-sm font-medium">
+                  <Link
+                    href="/estimate/list"
+                    className="block w-full text-sm font-medium"
+                  >
                     나의 견적서
                   </Link>
                 </li>
                 <li className="py-4">
-                  <Link href="/mypage" className="block w-full text-sm font-medium">
+                  <Link
+                    href="/mypage"
+                    className="block w-full text-sm font-medium"
+                  >
                     마이페이지
                   </Link>
                 </li>
                 <li className="py-4">
-                  <Link href="/logout" className="block w-full text-sm font-medium">
+                  <button
+                    onClick={handleLogout}
+                    className="block w-full text-left text-sm font-medium"
+                  >
                     로그아웃
-                  </Link>
+                  </button>
                 </li>
               </ul>
             </nav>


### PR DESCRIPTION
## 📌 개요
- 로그아웃 API 를 연동했습니다.
- 회원가입 완료시 관련 모달을 띄우고 로그인페이지로 연결되도록 했습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #51

## ✅ 변경 사항
- 로그아웃 API 연동
- URL 주소 변경
- 회원가입 완료 시 모달을 띄운 뒤 로그인 페이지로 이동

## 📝 상세 내용
- 로그아웃 API를 연동하여 로그아웃이 완료되면 관련 모달을 띄운 뒤 로그인 페이지로 이동하도록 했습니다.
- 헤더의 /home 주소를 /로 변경하고 /company는 /about 으로 변경했습니다.
- 회원가입 완료 시 회원가입에 성공했습니다. 라는 모달과 함게 컨페티 애니메이션이 보이도록 했습니다.
(위 사항은 로그인 성공시 애니메이션과 동일합니다. 현재 다수의 테스트로 이메일 인증을 추가로 할 수 없어 스크린샷은 로그인성공 애니메이션으로 추가해두었습니다.)

## 📸 스크린샷
| | |
|:-:|:-:|
|![image](https://github.com/user-attachments/assets/ee10f38a-09fc-4c81-aad0-73965565e2d2)|(로그인 성공과 회원가입 성공 시 보이는 효과는 동일)|
| ![image1](https://github.com/user-attachments/assets/038f0508-af33-4b65-9d37-c16e85d32252) |(로그아웃 성공시 모달을 띄운 후 로그인 페이지로 이동)|


