### PR TITLE
[Fix] Refresh Token 만료 기간 버그 수정 완료

### DIFF
--- a/backend/src/main/java/com/postdm/backend/domain/auth/application/AuthService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/application/AuthService.java
@@ -33,7 +33,7 @@ public class AuthService { // 로그인 및 회원가입 서비스
             CertificationRepository certificationRepository,
             BCryptPasswordEncoder bCryptPasswordEncoder,
             JwtProvider jwtProvider,
-            @Value("${jwt.expiredMS}") int refreshedMS,
+            @Value("${jwt.refreshedMs}") int refreshedMS,
             TokenBlacklistService tokenBlacklistService) {
         this.memberRepository = memberRepository;
         this.certificationRepository = certificationRepository;
@@ -126,15 +126,15 @@ public class AuthService { // 로그인 및 회원가입 서비스
         TokenInfo token = jwtProvider.generateToken(username, role); // 로그인이 완료되면 토큰 생성
         String refreshToken = jwtProvider.generateRefreshToken(username, role);
 
-        response.addCookie(createCookie("Refresh", refreshToken)); // 쿠키에 refresh 토큰 담음
+        response.addCookie(createCookie(refreshToken)); // 쿠키에 refresh 토큰 담음
 
 
         return token; // 응답 body에는 access 토큰 반환
     }
 
-    private Cookie createCookie(String name, String value) { // 쿠키 생성 메소드
-        Cookie cookie = new Cookie(name, value);
-        cookie.setMaxAge(refreshedMS);
+    private Cookie createCookie(String value) { // 쿠키 생성 메소드
+        Cookie cookie = new Cookie("Refresh", value);
+        cookie.setMaxAge(refreshedMS / 1000);
         cookie.setSecure(true);
         cookie.setHttpOnly(true);
 


### PR DESCRIPTION
## 📌 개요
- Refresh 토큰 만료 기간 관련 오류를 수정하였습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #57 

## ✅ 변경 사항
- AuthService 단에서의 Refresh Token 만료 기간을 Second(초 단위)가 아닌 Ms(밀리초 단위)로 수정하여 계산.

## 📝 상세 내용
- Refresh 토큰 만료 기간이 본래 밀리초(Ms)로 계산되어야 했으나, 기존 코드 내의 로그인 구현 과정에서 밀리초가 아닌 초(Second)단위로 환산되어 만료기간이 20년이 되는 문제가 발생했었습니다.
- Second 단위를 Ms로 환산하여 버그를 수정 완료 했습니다.
