### PR TITLE
[Feature] 마이페이지 조회 및 수정 기능 구현

### DIFF
--- a/backend/src/main/java/com/postdm/backend/domain/auth/api/TestController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/api/TestController.java
@@ -1,7 +1,9 @@
 package com.postdm.backend.domain.auth.api;
 
+import com.postdm.backend.domain.member.dto.MemberPrincipalDto;
 import com.postdm.backend.global.template.ResponseTemplate;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,11 +11,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class TestController { // 현재 사용자 세션 확인용 테스트 컨트롤러
     @GetMapping("/test")
-    public ResponseTemplate<String> test() {
-        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+    public ResponseTemplate<String> test(@AuthenticationPrincipal MemberPrincipalDto member) {
 
+        String nickname = member.getNickname();
         String role = SecurityContextHolder.getContext().getAuthentication().getAuthorities().iterator().next().getAuthority();
 
-        return new ResponseTemplate<>(HttpStatus.OK, "환영합니다, " + role + ", " + username + "님!", username);
+        return new ResponseTemplate<>(HttpStatus.OK, "환영합니다, " + role + ", " + nickname + "님!", nickname);
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/auth/application/AuthService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/auth/application/AuthService.java
@@ -117,10 +117,8 @@ public class AuthService { // 로그인 및 회원가입 서비스
     public TokenInfo signIn(SignInRequestDto signInRequestDto, HttpServletResponse response) { // 로그인 서비스
         String username = signInRequestDto.getUsername();
 
-        Member member = memberRepository.findByUsername(username);
-        if(member == null) {
-            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
-        }
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         String password = signInRequestDto.getPassword();
         String encodedPassword = member.getPassword();

--- a/backend/src/main/java/com/postdm/backend/domain/member/api/MemberController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/api/MemberController.java
@@ -5,6 +5,8 @@ import com.postdm.backend.domain.email.dto.CheckCertificationRequestDto;
 import com.postdm.backend.domain.member.application.MemberService;
 import com.postdm.backend.domain.member.domain.entity.Member;
 import com.postdm.backend.domain.member.dto.FindUsernameRequestDto;
+import com.postdm.backend.domain.member.dto.MemberInfoDto;
+import com.postdm.backend.domain.member.dto.MemberPrincipalDto;
 import com.postdm.backend.domain.member.dto.ResetPasswordRequestDto;
 import com.postdm.backend.global.template.ResponseTemplate;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,10 +14,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/member")
@@ -65,5 +65,21 @@ public class MemberController {
         Member member = memberService.resetPassword(requestDto);
 
         return new ResponseTemplate<>(HttpStatus.OK, "비밀번호 변경 성공", member);
+    }
+
+    @GetMapping("/my-page")
+    public ResponseTemplate<MemberInfoDto> memberInfo(@AuthenticationPrincipal MemberPrincipalDto memberPrincipalDto) {
+        String username = memberPrincipalDto.getUsername();
+        MemberInfoDto member = memberService.loadMemberInfo(username);
+        return new ResponseTemplate<>(HttpStatus.OK, "조회 성공", member);
+    }
+
+    @PatchMapping("/my-page/edit")
+    public ResponseTemplate<?> editMemberInfo(@AuthenticationPrincipal MemberPrincipalDto memberPrincipalDto,
+                                              @RequestBody MemberInfoDto memberInfoDto) {
+        String username = memberPrincipalDto.getUsername();
+        memberService.updateMemberInfo(username, memberInfoDto);
+
+        return new ResponseTemplate<>(HttpStatus.OK, "회원 정보 수정 성공");
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/member/api/MemberController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/api/MemberController.java
@@ -67,6 +67,10 @@ public class MemberController {
         return new ResponseTemplate<>(HttpStatus.OK, "비밀번호 변경 성공", member);
     }
 
+    @Operation(summary = "마이페이지 조회 컨트롤러")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @GetMapping("/my-page")
     public ResponseTemplate<MemberInfoDto> memberInfo(@AuthenticationPrincipal MemberPrincipalDto memberPrincipalDto) {
         String username = memberPrincipalDto.getUsername();
@@ -74,9 +78,13 @@ public class MemberController {
         return new ResponseTemplate<>(HttpStatus.OK, "조회 성공", member);
     }
 
+    @Operation(summary = "마이페이지 수정 컨트롤러")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PatchMapping("/my-page/edit")
     public ResponseTemplate<?> editMemberInfo(@AuthenticationPrincipal MemberPrincipalDto memberPrincipalDto,
-                                              @RequestBody MemberInfoDto memberInfoDto) {
+                                              @RequestBody @Valid MemberInfoDto memberInfoDto) {
         String username = memberPrincipalDto.getUsername();
         memberService.updateMemberInfo(username, memberInfoDto);
 

--- a/backend/src/main/java/com/postdm/backend/domain/member/application/MemberService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/application/MemberService.java
@@ -10,6 +10,7 @@ import com.postdm.backend.domain.member.dto.MemberInfoDto;
 import com.postdm.backend.domain.member.dto.ResetPasswordRequestDto;
 import com.postdm.backend.global.common.exception.CustomException;
 import com.postdm.backend.global.common.response.ErrorCode;
+import jakarta.validation.Valid;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -80,7 +81,7 @@ public class MemberService {
                 build();
     }
 
-    public void updateMemberInfo(String username, MemberInfoDto memberInfoDto) {
+    public void updateMemberInfo(String username, @Valid MemberInfoDto memberInfoDto) {
         Member member = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 

--- a/backend/src/main/java/com/postdm/backend/domain/member/application/MemberService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/application/MemberService.java
@@ -6,9 +6,17 @@ import com.postdm.backend.domain.email.dto.CheckCertificationRequestDto;
 import com.postdm.backend.domain.member.dto.FindUsernameRequestDto;
 import com.postdm.backend.domain.member.domain.entity.Member;
 import com.postdm.backend.domain.member.domain.repository.MemberRepository;
+import com.postdm.backend.domain.member.dto.MemberInfoDto;
 import com.postdm.backend.domain.member.dto.ResetPasswordRequestDto;
+import com.postdm.backend.global.common.exception.CustomException;
+import com.postdm.backend.global.common.response.ErrorCode;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 public class MemberService {
@@ -51,12 +59,46 @@ public class MemberService {
             throw new IllegalArgumentException();
         }
 
-        Member member = memberRepository.findByUsername(username);
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
         member.setPassword(encodedPassword);
 
         memberRepository.save(member);
         certificationRepository.delete(certificationEntity);
 
         return member;
+    }
+
+    public MemberInfoDto loadMemberInfo(String username) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return MemberInfoDto.builder().
+                nickname(member.getNickname()).
+                email(member.getEmail()).
+                phone(member.getPhone()).
+                build();
+    }
+
+    public void updateMemberInfo(String username, MemberInfoDto memberInfoDto) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<MemberInfoDto> list = new ArrayList<>();
+        list.add(memberInfoDto);
+
+        for(int i = 0; i < list.size(); i++) {
+            if(list.get(i).getNickname() != null) {
+                member.setNickname(list.get(i).getNickname());
+            };
+            if(list.get(i).getEmail() != null) {
+                member.setEmail(list.get(i).getEmail());
+            };
+            if(list.get(i).getPhone() != null) {
+                member.setPhone(list.get(i).getPhone());
+            };
+        }
+
+        memberRepository.save(member);
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/member/application/MemberService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/application/MemberService.java
@@ -88,15 +88,24 @@ public class MemberService {
         List<MemberInfoDto> list = new ArrayList<>();
         list.add(memberInfoDto);
 
-        for(int i = 0; i < list.size(); i++) {
-            if(list.get(i).getNickname() != null) {
-                member.setNickname(list.get(i).getNickname());
+        for (MemberInfoDto infoDto : list) {
+            if (infoDto.getNickname() != null) {
+                if (infoDto.getNickname().isEmpty()) {
+                    throw new CustomException(ErrorCode.VALIDATION_FAIL);
+                }
+                member.setNickname(infoDto.getNickname());
             };
-            if(list.get(i).getEmail() != null) {
-                member.setEmail(list.get(i).getEmail());
+            if (infoDto.getEmail() != null) {
+                if(infoDto.getEmail().isEmpty()) {
+                    throw new CustomException(ErrorCode.VALIDATION_FAIL);
+                }
+                member.setEmail(infoDto.getEmail());
             };
-            if(list.get(i).getPhone() != null) {
-                member.setPhone(list.get(i).getPhone());
+            if (infoDto.getPhone() != null) {
+                if (infoDto.getPhone().isEmpty()) {
+                    throw new CustomException(ErrorCode.VALIDATION_FAIL);
+                }
+                member.setPhone(infoDto.getPhone());
             };
         }
 

--- a/backend/src/main/java/com/postdm/backend/domain/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/domain/repository/MemberRepository.java
@@ -4,10 +4,12 @@ import com.postdm.backend.domain.member.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
     boolean existsByUsername(String username);
-    Member findByUsername(String username);
+    Optional<Member> findByUsername(String username);
     Member findByEmail(String email);
 }

--- a/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberInfoDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberInfoDto.java
@@ -1,17 +1,22 @@
 package com.postdm.backend.domain.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import lombok.Builder;
 import lombok.Data;
 
+@Schema(description = "마이페이지 정보 DTO")
 @Data
 @Builder
 public class MemberInfoDto {
 
+    @Schema(description = "사용자 이름", example = "홍길동")
     private String nickname;
 
+    @Schema(description = "사용자 이메일", example = "test1@test.com")
     @Email
     private String email;
 
+    @Schema(description = "사용자 전화번호", example = "01012345678")
     private String phone;
 }

--- a/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberInfoDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberInfoDto.java
@@ -1,0 +1,15 @@
+package com.postdm.backend.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberInfoDto {
+
+    private String nickname;
+
+    private String username;
+
+    private String phone;
+}

--- a/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberInfoDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberInfoDto.java
@@ -1,5 +1,6 @@
 package com.postdm.backend.domain.member.dto;
 
+import jakarta.validation.constraints.Email;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,6 +10,7 @@ public class MemberInfoDto {
 
     private String nickname;
 
+    @Email
     private String email;
 
     private String phone;

--- a/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberInfoDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberInfoDto.java
@@ -9,7 +9,7 @@ public class MemberInfoDto {
 
     private String nickname;
 
-    private String username;
+    private String email;
 
     private String phone;
 }

--- a/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberPrincipalDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberPrincipalDto.java
@@ -1,6 +1,6 @@
 package com.postdm.backend.domain.member.dto;
 
-import com.postdm.backend.domain.member.domain.entity.MemberRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,8 +10,10 @@ public class MemberPrincipalDto {
 
     private Long id;
 
+    @Schema(description = "사용자 이름", example = "홍길동")
     private String nickname;
 
+    @Schema(description = "사용자 아이디", example = "test123")
     private String username;
 
 }

--- a/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberPrincipalDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/dto/MemberPrincipalDto.java
@@ -1,0 +1,17 @@
+package com.postdm.backend.domain.member.dto;
+
+import com.postdm.backend.domain.member.domain.entity.MemberRole;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberPrincipalDto {
+
+    private Long id;
+
+    private String nickname;
+
+    private String username;
+
+}

--- a/backend/src/main/java/com/postdm/backend/global/jwt/util/JwtProvider.java
+++ b/backend/src/main/java/com/postdm/backend/global/jwt/util/JwtProvider.java
@@ -97,7 +97,6 @@ public class JwtProvider { // JWT 발급을 위한 Provider
     public TokenInfo generateToken(String username, String role) { // 토큰 생성
 
         String accessToken = generateAccessToken(username, role);
-        String refreshToken = generateRefreshToken(username, role);
 
         return TokenInfo.builder()
                 .grantType("Bearer")

--- a/backend/src/main/java/com/postdm/backend/global/jwt/util/JwtProvider.java
+++ b/backend/src/main/java/com/postdm/backend/global/jwt/util/JwtProvider.java
@@ -2,6 +2,9 @@ package com.postdm.backend.global.jwt.util;
 
 import com.postdm.backend.domain.member.domain.entity.Member;
 import com.postdm.backend.domain.member.domain.repository.MemberRepository;
+import com.postdm.backend.domain.member.dto.MemberPrincipalDto;
+import com.postdm.backend.global.common.exception.CustomException;
+import com.postdm.backend.global.common.response.ErrorCode;
 import com.postdm.backend.global.jwt.dto.TokenInfo;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SecurityException;
@@ -110,15 +113,19 @@ public class JwtProvider { // JWT 발급을 위한 Provider
 
         String role = claims.get("role", String.class);  // role 추출
 
-        Member member = memberRepository.findByUsername(username);
-        if (member == null) {
-            throw new RuntimeException("해당 사용자 정보를 찾을 수 없습니다.");
-        }
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        MemberPrincipalDto memberPrincipalDto = MemberPrincipalDto.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .username(username)
+                .build();
 
         List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role));
 
         // Spring Security에서 Authentication 객체의 principal을 Member 객체로 저장
-        return new UsernamePasswordAuthenticationToken(member, "", authorities);
+        return new UsernamePasswordAuthenticationToken(memberPrincipalDto, "", authorities);
     }
 
     // JWT 토큰 만료 시간 반환


### PR DESCRIPTION
## 📌 개요
- 포스트디엠의 마이페이지 조회 및 수정 기능을 구현하였습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #60 

## ✅ 변경 사항
- 포스트디엠의 마이페이지 조회 기능이 추가되었습니다.
- 포스트디엠의 회원 정보 수정 기능이 추가되었습니다.
- 추가적으로, 이전에는 로그인 구현 파트에서 사용자의 모든 정보가 SecurityContextHolder에 등록되었지만 보안상 좋지 않은 방법이라 판단되어, 사용자의 PK, 닉네임, 아이디만 등록될 수 있도록 하였습니다.

## 📝 상세 내용
- 사용자는 api/v1/member/my-page를 통해 자신의 회원 정보를 조회할 수 있습니다.
- 사용자는 api/v1/member/my-page/edit을 통해 자신의 회원 정보를 수정할 수 있습니다.
  - 회원정보 수정 시에는 모든 정보 혹은 특정 정보만 수정이 가능하며, 공백 값만 입력하는 것은 불가능 합니다. 

## 📸 스크린샷
- 회원정보 조회 성공 시 예시(Swagger) 
  ![image](https://github.com/user-attachments/assets/b9ead4f4-5dda-4f96-9323-08bd3bd85cfb)
- 회원정보 수정 성공 시 예시(Swagger) 
  ![image](https://github.com/user-attachments/assets/63b29b99-b72e-4417-b2b6-6d770629be8f)
