### PR TITLE
[Refactor] 견적서 API MemberPrincipalDto 적용

### DIFF
--- a/backend/src/main/java/com/postdm/backend/domain/estimate/controller/EstimateController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/controller/EstimateController.java
@@ -3,17 +3,14 @@ package com.postdm.backend.domain.estimate.controller;
 import com.postdm.backend.domain.estimate.dto.EstimateRequestDto;
 import com.postdm.backend.domain.estimate.dto.EstimateResponseDto;
 import com.postdm.backend.domain.estimate.service.EstimateService;
-import com.postdm.backend.domain.member.domain.entity.Member;
+import com.postdm.backend.domain.member.dto.MemberPrincipalDto;
 import com.postdm.backend.global.template.ResponseTemplate;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -32,28 +29,32 @@ public class EstimateController {
 
     @Operation(summary = "견적서 생성", description = "새로운 견적서를 생성합니다. 사용자는 content만 입력하며, title은 자동 생성됩니다.")
     @PostMapping
-    public ResponseTemplate<EstimateResponseDto> createEstimate(@AuthenticationPrincipal Member currentUser,
-                                                                @RequestBody @Valid EstimateRequestDto requestDto) {
+    public ResponseEntity<ResponseTemplate<EstimateResponseDto>> createEstimate(@AuthenticationPrincipal MemberPrincipalDto currentUser,
+                                                                @RequestBody EstimateRequestDto requestDto) {
 
         EstimateResponseDto response = estimateService.createEstimate(requestDto.getContent(), currentUser);
 
-        return new ResponseTemplate<>(HttpStatus.CREATED, "견적서 생성 성공", response);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new ResponseTemplate<>(HttpStatus.CREATED, "견적서 생성 성공", response));
     }
 
     @Operation(summary = "견적서 조회", description = "관리자는 모든 견적서를, 사용자는 본인의 견적서만 조회합니다.")
     @GetMapping
-    public ResponseTemplate<List<EstimateResponseDto>> getEstimates(@AuthenticationPrincipal Member currentUser) {
+    public ResponseEntity<ResponseTemplate<List<EstimateResponseDto>>> getEstimates(@AuthenticationPrincipal MemberPrincipalDto currentUser) {
         List<EstimateResponseDto> response = estimateService.getEstimates(currentUser);
-        return new ResponseTemplate<>(HttpStatus.OK, "견적서 조회 성공", response);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ResponseTemplate<>(HttpStatus.OK, "견적서 조회 성공", response));
     }
 
     @Operation(summary = "견적서 상세 조회", description = "사용자의 특정 견적서를 상세 조회합니다.")
     @GetMapping("/{estimateId}")
-    public ResponseTemplate<EstimateResponseDto> getEstimateDetail(@PathVariable Long estimateId) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Member member = (Member) authentication.getPrincipal();
-
-        EstimateResponseDto response = estimateService.getEstimateDetail(estimateId, member);
-        return new ResponseTemplate<>(HttpStatus.OK, "견적서 상세 조회 성공", response);
+    public ResponseEntity<ResponseTemplate<EstimateResponseDto>> getEstimateDetail(@PathVariable Long estimateId,
+                                                                   @AuthenticationPrincipal MemberPrincipalDto principal) {
+        EstimateResponseDto response = estimateService.getEstimateDetail(estimateId, principal);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ResponseTemplate<>(HttpStatus.OK, "견적서 상세 조회 성공", response));
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/service/EstimateService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/service/EstimateService.java
@@ -6,104 +6,68 @@ import com.postdm.backend.domain.estimate.entity.EstimateRepository;
 import com.postdm.backend.domain.estimate.service.policy.AdminEstimatePolicy;
 import com.postdm.backend.domain.estimate.service.policy.UserEstimatePolicy;
 import com.postdm.backend.domain.member.domain.entity.Member;
+import com.postdm.backend.domain.member.domain.entity.MemberRole;
+import com.postdm.backend.domain.member.domain.repository.MemberRepository;
+import com.postdm.backend.domain.member.dto.MemberPrincipalDto;
 import com.postdm.backend.global.common.exception.CustomException;
 import com.postdm.backend.global.common.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.postdm.backend.domain.member.domain.entity.MemberRole.ADMIN;
-
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class EstimateService {
     private final EstimateRepository estimateRepository;
+    private final MemberRepository memberRepository;
     private final AdminEstimatePolicy adminPolicy;
     private final UserEstimatePolicy userPolicy;
 
-    public EstimateService(EstimateRepository estimateRepository,
-                           AdminEstimatePolicy adminPolicy,
-                           UserEstimatePolicy userPolicy) {
-        this.estimateRepository = estimateRepository;
-        this.adminPolicy = adminPolicy;
-        this.userPolicy = userPolicy;
-    }
-
-    public EstimateResponseDto createEstimate(String content, Member member) {
+    public EstimateResponseDto createEstimate(String content, MemberPrincipalDto principal) {
         if (content == null || content.trim().isEmpty()) {
             throw new CustomException(ErrorCode.ESTIMATE_NULL);
         }
 
-        if (member == null) {
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            if (authentication != null && authentication.getPrincipal() instanceof Member) {
-                member = (Member) authentication.getPrincipal();
-            } else {
-                throw new CustomException(ErrorCode.AUTHORIZED_MEMBER_NOT_FOUND);
-            }
-        }
+        Member member = findMemberOrThrow(principal.getId());
 
         Estimate estimate = new Estimate(content, member);
-        Estimate savedEstimate = estimateRepository.save(estimate);
+        Estimate saved = estimateRepository.save(estimate);
 
         return new EstimateResponseDto(
-            savedEstimate.getId(),
-            savedEstimate.getTitle(),
-            savedEstimate.getContent(),
-            savedEstimate.getCreatedAt(),
-            savedEstimate.getMember().getId()
+            saved.getId(),
+            saved.getTitle(),
+            saved.getContent(),
+            saved.getCreatedAt(),
+            saved.getMember().getId()
         );
     }
 
-    public List<EstimateResponseDto> getEstimates(Member member) {
-        if (member == null) {
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            if (authentication != null && authentication.getPrincipal() instanceof Member) {
-                member = (Member) authentication.getPrincipal();
-            } else {
-                throw new CustomException(ErrorCode.AUTHORIZED_MEMBER_NOT_FOUND);
-            }
-        }
+    public List<EstimateResponseDto> getEstimates(MemberPrincipalDto principal) {
+        Member member = findMemberOrThrow(principal.getId());
 
-        List<Estimate> estimates;
-
-        if (member.getRole() == ADMIN) {
-            estimates = adminPolicy.getEstimates(member, estimateRepository);
-        } else {
-            estimates = userPolicy.getEstimates(member, estimateRepository);
-        }
+        List<Estimate> estimates = (member.getRole() == MemberRole.ADMIN)
+                ? adminPolicy.getEstimates(member, estimateRepository)
+                : userPolicy.getEstimates(member, estimateRepository);
 
         return estimates.stream()
-                .map(estimate -> new EstimateResponseDto(
-                        estimate.getId(),
-                        estimate.getTitle(),
-                        estimate.getContent(),
-                        estimate.getCreatedAt(),
-                        estimate.getMember().getId()
+                .map(e -> new EstimateResponseDto(
+                        e.getId(), e.getTitle(), e.getContent(), e.getCreatedAt(), e.getMember().getId()
                 ))
                 .collect(Collectors.toList());
     }
 
-    public EstimateResponseDto getEstimateDetail(Long estimateId, Member member) {
-        if (member == null) {
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            if (authentication != null && authentication.getPrincipal() instanceof Member) {
-                member = (Member) authentication.getPrincipal();
-            } else {
-                throw new CustomException(ErrorCode.AUTHORIZED_MEMBER_NOT_FOUND);
-            }
-        }
+    public EstimateResponseDto getEstimateDetail(Long estimateId, MemberPrincipalDto principal) {
+        Member member = findMemberOrThrow(principal.getId());
 
         Estimate estimate = estimateRepository.findById(estimateId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ESTIMATE_NOT_FOUND));
 
-        // 권한 체크
-        if (member.getRole() != ADMIN &&
-                estimate.getMember().getId() != member.getId()) {
+        if (member.getRole() != MemberRole.ADMIN
+                && estimate.getMember().getId() != member.getId()) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 
@@ -114,5 +78,10 @@ public class EstimateService {
             estimate.getCreatedAt(),
             estimate.getMember().getId()
         );
+    }
+
+    private Member findMemberOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTHORIZED_MEMBER_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/member/dto/TestPrincipalFactory.java
+++ b/backend/src/main/java/com/postdm/backend/domain/member/dto/TestPrincipalFactory.java
@@ -1,0 +1,14 @@
+package com.postdm.backend.domain.member.dto;
+
+import com.postdm.backend.domain.member.domain.entity.Member;
+
+public class TestPrincipalFactory {
+
+    public static MemberPrincipalDto create(Member member) {
+        return new MemberPrincipalDto(
+                member.getId(),
+                member.getNickname(),
+                member.getUsername()
+        );
+    }
+}

--- a/backend/src/test/java/com/postdm/backend/domain/estimate/controller/EstimateControllerTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/estimate/controller/EstimateControllerTest.java
@@ -4,18 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.postdm.backend.domain.estimate.dto.EstimateRequestDto;
 import com.postdm.backend.domain.estimate.entity.Estimate;
 import com.postdm.backend.domain.estimate.entity.EstimateRepository;
-import com.postdm.backend.domain.estimate.service.EstimateService;
 import com.postdm.backend.domain.member.domain.entity.Member;
 import com.postdm.backend.domain.member.domain.entity.MemberRole;
 import com.postdm.backend.domain.member.domain.repository.MemberRepository;
+import com.postdm.backend.domain.member.dto.MemberPrincipalDto;
+import com.postdm.backend.domain.member.dto.TestPrincipalFactory;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,7 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -36,7 +33,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
-@ExtendWith(MockitoExtension.class)
 class EstimateControllerTest {
 
     @Autowired
@@ -51,65 +47,52 @@ class EstimateControllerTest {
     @Autowired
     private EstimateRepository estimateRepository;
 
-    @Mock
-    private EstimateService estimateService;
-
-    @InjectMocks
-    private EstimateController estimateController;
-
     private Member testMember;
     private Estimate testEstimate;
+    private Authentication authentication;
 
     @BeforeEach
     void setUp() {
         estimateRepository.deleteAll();
         memberRepository.deleteAll();
 
-        testMember = new Member(0L, "testUser", "test1", "password", "test@example.com", "01011111111", MemberRole.MEMBER);
+        testMember = new Member(0L, "testUser", "nickname", "pass", "email@example.com", "01012345678", MemberRole.MEMBER);
         testMember = memberRepository.saveAndFlush(testMember);
 
         testEstimate = new Estimate("테스트 견적 내용입니다.", testMember);
         estimateRepository.saveAndFlush(testEstimate);
 
-        Authentication auth = new UsernamePasswordAuthenticationToken(
-                testMember, null,
+        MemberPrincipalDto principal = TestPrincipalFactory.create(testMember);
+
+        authentication = new UsernamePasswordAuthenticationToken(
+                principal, null,
                 Collections.singletonList(new SimpleGrantedAuthority("ROLE_MEMBER"))
         );
-        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
     @Test
     @DisplayName("견적서 생성 API 테스트")
     void 견적서_생성_API_테스트() throws Exception {
-        // Given
-        String requestJson = objectMapper.writeValueAsString(new EstimateRequestDto("테스트 견적서 내용입니다."));
+        String requestJson = objectMapper.writeValueAsString(
+                new EstimateRequestDto("테스트 견적서 내용입니다.")
+        );
 
-        // When & Then
         mockMvc.perform(post("/api/v1/estimates")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authentication))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestJson))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.content").value("테스트 견적서 내용입니다."));
     }
 
     @Test
     @DisplayName("견적서 조회 API 테스트")
     void 견적서_조회_API_테스트() throws Exception {
-        // When & Then
         mockMvc.perform(get("/api/v1/estimates")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authentication))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.size()").value(1))
                 .andExpect(jsonPath("$.data[0].content").value("테스트 견적 내용입니다."));
-    }
-
-    @Test
-    @DisplayName("인증되지 않은 사용자가 견적서를 조회하면 403 응답을 반환해야 한다")
-    void 인증되지_않은_사용자가_견적서를_조회하면_403_반환() throws Exception {
-        SecurityContextHolder.clearContext();
-
-        mockMvc.perform(get("/api/v1/estimates")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isForbidden());
     }
 }

--- a/backend/src/test/java/com/postdm/backend/domain/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/estimate/service/EstimateServiceTest.java
@@ -7,6 +7,9 @@ import com.postdm.backend.domain.estimate.entity.EstimateRepository;
 import com.postdm.backend.domain.member.domain.entity.Member;
 import com.postdm.backend.domain.member.domain.entity.MemberRole;
 import com.postdm.backend.domain.member.domain.repository.MemberRepository;
+import com.postdm.backend.domain.member.dto.MemberPrincipalDto;
+import com.postdm.backend.domain.member.dto.TestPrincipalFactory;
+import com.postdm.backend.global.common.exception.CustomException;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -66,13 +69,14 @@ class EstimateServiceTest {
     @Test
     @DisplayName("견적서를 생성하면 정상적으로 반환해야 한다")
     void 견적서를_생성하면_정상적으로_반환() {
-        // Given
+        // given
         EstimateRequestDto requestDto = new EstimateRequestDto("새로운 견적서 내용입니다.");
+        MemberPrincipalDto principal = TestPrincipalFactory.create(testMember);
 
-        // When
-        EstimateResponseDto responseDto = estimateService.createEstimate(requestDto.getContent(), testMember);
+        // when
+        EstimateResponseDto responseDto = estimateService.createEstimate(requestDto.getContent(), principal);
 
-        // Then
+        // then
         assertThat(responseDto).isNotNull();
         assertThat(responseDto.getContent()).isEqualTo("새로운 견적서 내용입니다.");
         assertThat(responseDto.getMemberId()).isEqualTo(testMember.getId());
@@ -82,19 +86,23 @@ class EstimateServiceTest {
     @DisplayName("비어 있는 내용으로 견적서를 생성하면 예외가 발생해야 한다")
     void 비어있는_내용으로_견적서를_생성하면_예외가_발생() {
         EstimateRequestDto requestDto = new EstimateRequestDto("");
+        MemberPrincipalDto principal = TestPrincipalFactory.create(testMember);
 
         assertThrows(RuntimeException.class, () -> {
-            estimateService.createEstimate(requestDto.getContent(), testMember);
+            estimateService.createEstimate(requestDto.getContent(), principal);
         });
     }
 
     @Test
     @DisplayName("사용자가 본인의 견적서를 조회할 수 있다")
     void 사용자가_본인의_견적서를_조회() {
-        // When
-        List<EstimateResponseDto> estimates = estimateService.getEstimates(testMember);
+        // given
+        MemberPrincipalDto principal = TestPrincipalFactory.create(testMember);
 
-        // Then
+        // when
+        List<EstimateResponseDto> estimates = estimateService.getEstimates(principal);
+
+        // then
         assertThat(estimates).isNotEmpty();
         assertThat(estimates.get(0).getContent()).isEqualTo(testEstimate.getContent());
         assertThat(estimates.get(0).getMemberId()).isEqualTo(testMember.getId());
@@ -116,8 +124,11 @@ class EstimateServiceTest {
     @Test
     @DisplayName("일반 사용자가 본인의 견적서를 상세 조회할 수 있다")
     void 일반_사용자는_자신의_견적서_상세_조회_가능() {
+        // given
+        MemberPrincipalDto principal = TestPrincipalFactory.create(testMember);
+
         // when
-        EstimateResponseDto response = estimateService.getEstimateDetail(testEstimate.getId(), testMember);
+        EstimateResponseDto response = estimateService.getEstimateDetail(testEstimate.getId(), principal);
 
         // then
         assertThat(response).isNotNull();
@@ -132,9 +143,11 @@ class EstimateServiceTest {
         Member otherUser = new Member(0L, "otherUser", "nickname2", "pass", "other@ex.com", "01012345678", MemberRole.MEMBER);
         memberRepository.saveAndFlush(otherUser);
 
+        MemberPrincipalDto otherPrincipal = TestPrincipalFactory.create(otherUser);
+
         // when & then
-        assertThrows(RuntimeException.class, () -> {
-            estimateService.getEstimateDetail(testEstimate.getId(), otherUser);
+        assertThrows(CustomException.class, () -> {
+            estimateService.getEstimateDetail(testEstimate.getId(), otherPrincipal);
         });
     }
 
@@ -144,9 +157,10 @@ class EstimateServiceTest {
         // given
         Member admin = new Member(0L, "admin", "관리자", "adminpass", "admin@ex.com", "01000000000", MemberRole.ADMIN);
         memberRepository.saveAndFlush(admin);
+        MemberPrincipalDto principal = TestPrincipalFactory.create(testMember);
 
         // when
-        EstimateResponseDto response = estimateService.getEstimateDetail(testEstimate.getId(), admin);
+        EstimateResponseDto response = estimateService.getEstimateDetail(testEstimate.getId(), principal);
 
         // then
         assertThat(response).isNotNull();

--- a/backend/src/test/java/com/postdm/backend/domain/integration/LogoutIntegrationTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/integration/LogoutIntegrationTest.java
@@ -1,7 +1,6 @@
-package com.postdm.backend.domain.estimate.integration;
+package com.postdm.backend.domain.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.postdm.backend.domain.auth.dto.SignInRequestDto;
 import com.postdm.backend.domain.auth.repository.TokenBlacklistRepository;
 import com.postdm.backend.domain.member.domain.entity.Member;
 import com.postdm.backend.domain.member.domain.entity.MemberRole;
@@ -10,17 +9,14 @@ import com.postdm.backend.global.jwt.dto.TokenInfo;
 import com.postdm.backend.global.jwt.util.JwtProvider;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -57,7 +53,6 @@ class LogoutIntegrationTest {
         String rawPassword = "testpassword1!";
         String encodedPassword = passwordEncoder.encode(rawPassword);
 
-        // 테스트용 사용자 등록
         Member member = Member.builder()
                 .username("홍길동")
                 .password(encodedPassword)

--- a/backend/src/test/java/com/postdm/backend/domain/integration/ReissueIntegrationTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/integration/ReissueIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.postdm.backend.domain.estimate.integration;
+package com.postdm.backend.domain.integration;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
## 📌 개요
- 보안상 SecurityContextHolder에 사용자의 PK, 닉네임, 아이디만 등록하게 변경되어, 기존 `Member` 엔티티를 직접 사용하던 로직을 `MemberPrincipalDto` 기반으로 리팩토링했습니다.
- 이에 따라 견적서 생성, 조회, 상세 조회 API도 `MemberPrincipalDto`를 이용하도록 수정했습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #63 

## ✅ 변경 사항
- `SecurityContextHolder` 인증 객체를 `Member`에서 `MemberPrincipalDto`로 변경
- `EstimateService`에서 `MemberPrincipalDto` 기반 사용자 인증 처리 적용
- `EstimateController`에서 `@AuthenticationPrincipal`로 principal 주입
- 테스트 코드 전체 리팩토링 (MockMvc에서 인증 객체 설정 방식 변경)
- 테스트 유틸 `TestPrincipalFactory` 추가로 인증 객체 표준 생성

## 📝 상세 내용
- 기존에는 `SecurityContextHolder`에 `Member` 엔티티 전체가 등록되어 있었으나, 보안상 과도한 정보 노출 우려로 인해 `MemberPrincipalDto`로 최소 정보만 등록
- 서비스 계층에서는 `principal.getId()`로 사용자 식별 후, `memberRepository.findById()`를 통해 최신 사용자 상태 반영
- 테스트에서는 `SecurityMockMvcRequestPostProcessors.authentication()`을 사용해 실제 인증과 동일하게 처리
- 테스트 전용 인증 객체 생성을 위한 `TestPrincipalFactory`를 도입하여 생성자 공개 없이 안전하게 principal 생성

## 🔎 기타
- 로그인 이후 처리되는 로그아웃, 토큰 재발급 기능에서도 `SecurityContext`의 principal을 항상 `MemberPrincipalDto`로 캐스팅해서 사용하도록 수정해야 합니다.
