### PR TITLE
[Feature] API 성능 테스트 환경 구성

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	// AOP
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 	// Email
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/entity/Estimate.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/entity/Estimate.java
@@ -2,6 +2,7 @@ package com.postdm.backend.domain.estimate.entity;
 
 import com.postdm.backend.domain.member.domain.entity.Member;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,6 +26,7 @@ public class Estimate {
 
     private LocalDateTime createdAt;
 
+    @Builder
     public Estimate(String content, Member member) {
         this.title = generateTitle(content);
         this.content = content;

--- a/backend/src/main/java/com/postdm/backend/global/common/aop/PerformanceLogAspect.java
+++ b/backend/src/main/java/com/postdm/backend/global/common/aop/PerformanceLogAspect.java
@@ -1,0 +1,21 @@
+package com.postdm.backend.global.common.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class PerformanceLogAspect {
+    @Around("execution(* com.postdm.backend.domain.estimate..*(..))")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long end = System.currentTimeMillis();
+        log.info("[PERF] " + joinPoint.getSignature() + " took " + (end - start) + "ms");
+        return result;
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/global/init/DummyDataInitializer.java
+++ b/backend/src/main/java/com/postdm/backend/global/init/DummyDataInitializer.java
@@ -1,0 +1,46 @@
+package com.postdm.backend.global.init;
+
+import com.postdm.backend.domain.estimate.entity.Estimate;
+import com.postdm.backend.domain.estimate.entity.EstimateRepository;
+import com.postdm.backend.domain.member.domain.entity.Member;
+import com.postdm.backend.domain.member.domain.repository.MemberRepository;
+import com.postdm.backend.global.common.exception.CustomException;
+import com.postdm.backend.global.common.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile("dev") // 로컬에서만 실행되도록 제한
+public class DummyDataInitializer implements CommandLineRunner {
+    private final EstimateRepository estimateRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void run(String... args) {
+        if (estimateRepository.count() > 0) {
+            log.info("[INIT] 이미 견적서 데이터가 존재합니다. 초기화를 건너뜁니다.");
+            return;
+        }
+
+        log.info("[INIT] 더미 견적서 생성 시작");
+
+        Member member = memberRepository.findById(1L)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        for (int i = 0; i < 10000; i++) {
+            Estimate estimate = Estimate.builder()
+                    .content("더미 데이터 자동 생성 " + i)
+                    .member(member)
+                    .build();
+            estimateRepository.save(estimate);
+        }
+
+        log.info("[INIT] 테스트용 견적서 10000건 삽입 완료");
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: backend
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:prod} # 로컬 테스트 시, dev로 변경
     
 # Swagger 설정
 springdoc:


### PR DESCRIPTION
## 📌 개요  
- API 성능 분석을 위한 AOP 기반 실행 시간 측정 기능 추가  
- 테스트용 견적서 데이터를 삽입하는 `DummyDataInitializer` 클래스 추가

## 🚀 관련 이슈
- 관련된 이슈 번호: #62 

## ✅ 변경 사항  
- `global/common/aop/PerformanceLogAspect` 추가
  - `@Around` 방식으로 서비스/컨트롤러 실행 시간 로그 출력
  - 로그 포맷: `[PERF] com.postdm... took 42ms`
- `global/init/DummyDataInitializer` 추가
  - `@Profile("dev")` 기반으로 실행: 로컬 테스트 시, 기본 프로파일을 `dev`로 수정 필요
  - 견적서 데이터가 비어 있는 경우, 10000건의 테스트용 데이터 자동 삽입
 
## 📝 상세 내용  
- `DummyDataInitializer`는 `estimateRepository.count() > 0` 조건으로 중복 삽입 방지
- `PerformanceLogAspect`는 `execution(* com.postdm.backend.domain.estimate..*(..))` 기반으로 특정 도메인 서비스 실행 시간 측정
- 성능 테스트 결과는 별도 이슈로 업로드 예정

