### PR TITLE
[Feature] 견적서 조회 페이지네이션 적용

### DIFF
--- a/backend/src/main/java/com/postdm/backend/domain/estimate/controller/EstimateController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/controller/EstimateController.java
@@ -2,6 +2,7 @@ package com.postdm.backend.domain.estimate.controller;
 
 import com.postdm.backend.domain.estimate.dto.EstimateRequestDto;
 import com.postdm.backend.domain.estimate.dto.EstimateResponseDto;
+import com.postdm.backend.domain.estimate.dto.PageResponse;
 import com.postdm.backend.domain.estimate.service.EstimateService;
 import com.postdm.backend.domain.member.dto.MemberPrincipalDto;
 import com.postdm.backend.global.template.ResponseTemplate;
@@ -44,10 +45,11 @@ public class EstimateController {
 
     @Operation(summary = "견적서 조회", description = "관리자는 모든 견적서를, 사용자는 본인의 견적서만 조회합니다.")
     @GetMapping
-    public ResponseEntity<ResponseTemplate<Page<EstimateResponseDto>>> getEstimates(
+    public ResponseEntity<ResponseTemplate<PageResponse<EstimateResponseDto>>> getEstimates(
             @AuthenticationPrincipal MemberPrincipalDto currentUser,
             @PageableDefault(page = 0, size = 6, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<EstimateResponseDto> response = estimateService.getEstimates(currentUser, pageable);
+        Page<EstimateResponseDto> page = estimateService.getEstimates(currentUser, pageable);
+        PageResponse<EstimateResponseDto> response = new PageResponse<>(page);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ResponseTemplate<>(HttpStatus.OK, "견적서 조회 성공", response));

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/controller/EstimateController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/controller/EstimateController.java
@@ -1,5 +1,6 @@
 package com.postdm.backend.domain.estimate.controller;
 
+import com.postdm.backend.domain.estimate.dto.EstimateListResponseDto;
 import com.postdm.backend.domain.estimate.dto.EstimateRequestDto;
 import com.postdm.backend.domain.estimate.dto.EstimateResponseDto;
 import com.postdm.backend.domain.estimate.dto.PageResponse;
@@ -45,11 +46,11 @@ public class EstimateController {
 
     @Operation(summary = "견적서 조회", description = "관리자는 모든 견적서를, 사용자는 본인의 견적서만 조회합니다.")
     @GetMapping
-    public ResponseEntity<ResponseTemplate<PageResponse<EstimateResponseDto>>> getEstimates(
+    public ResponseEntity<ResponseTemplate<PageResponse<EstimateListResponseDto>>> getEstimates(
             @AuthenticationPrincipal MemberPrincipalDto currentUser,
-            @PageableDefault(page = 0, size = 6, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<EstimateResponseDto> page = estimateService.getEstimates(currentUser, pageable);
-        PageResponse<EstimateResponseDto> response = new PageResponse<>(page);
+            @PageableDefault(page = 0, size = 6, sort = {"id"}, direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<EstimateListResponseDto> page = estimateService.getEstimates(currentUser, pageable);
+        PageResponse<EstimateListResponseDto> response = PageResponse.from(page);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ResponseTemplate<>(HttpStatus.OK, "견적서 조회 성공", response));

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/controller/EstimateController.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/controller/EstimateController.java
@@ -8,12 +8,15 @@ import com.postdm.backend.global.template.ResponseTemplate;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Page;
 
-import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 @Slf4j
 @Tag(name = "Estimate API", description = "견적서 관련 API")
@@ -41,8 +44,10 @@ public class EstimateController {
 
     @Operation(summary = "견적서 조회", description = "관리자는 모든 견적서를, 사용자는 본인의 견적서만 조회합니다.")
     @GetMapping
-    public ResponseEntity<ResponseTemplate<List<EstimateResponseDto>>> getEstimates(@AuthenticationPrincipal MemberPrincipalDto currentUser) {
-        List<EstimateResponseDto> response = estimateService.getEstimates(currentUser);
+    public ResponseEntity<ResponseTemplate<Page<EstimateResponseDto>>> getEstimates(
+            @AuthenticationPrincipal MemberPrincipalDto currentUser,
+            @PageableDefault(page = 0, size = 6, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<EstimateResponseDto> response = estimateService.getEstimates(currentUser, pageable);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ResponseTemplate<>(HttpStatus.OK, "견적서 조회 성공", response));

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateListResponseDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateListResponseDto.java
@@ -1,0 +1,25 @@
+package com.postdm.backend.domain.estimate.dto;
+
+import com.postdm.backend.domain.estimate.entity.Estimate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class EstimateListResponseDto {
+    private Long id;
+    private String title;
+    private LocalDateTime createdAt;
+    private Long memberId;
+
+    public static EstimateListResponseDto from(Estimate estimate) {
+        return new EstimateListResponseDto(
+                estimate.getId(),
+                estimate.getTitle(),
+                estimate.getCreatedAt(),
+                estimate.getMember().getId()
+        );
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateResponseDto.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/dto/EstimateResponseDto.java
@@ -1,18 +1,21 @@
 package com.postdm.backend.domain.estimate.dto;
 
+import com.postdm.backend.domain.estimate.entity.Estimate;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Schema(description = "견적서 응답 DTO")
+@AllArgsConstructor
 public class EstimateResponseDto {
 
     @Schema(description = "견적서 ID", example = "1")
     private Long id;
 
-    @Schema(description = "견적서 제목 (내용 앞 10글자 + ... 자동 생성)", example = "이것은 견적서의 내...")
+    @Schema(description = "견적서 제목 (내용 앞 10글자 + **** 자동 생성)", example = "이것은 견적서의 내...")
     private String title;
 
     @Schema(description = "견적서 내용", example = "이것은 견적서의 내용입니다.")
@@ -24,11 +27,13 @@ public class EstimateResponseDto {
     @Schema(description = "작성자", example = "user1")
     private Long memberId;
 
-    public EstimateResponseDto(Long id, String title, String content, LocalDateTime createdAt, Long memberId) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.memberId = memberId;
+    public static EstimateResponseDto from(Estimate estimate) {
+        return new EstimateResponseDto(
+                estimate.getId(),
+                estimate.getTitle(),
+                estimate.getContent(),
+                estimate.getCreatedAt(),
+                estimate.getMember().getId()
+        );
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/dto/PageResponse.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/dto/PageResponse.java
@@ -1,14 +1,16 @@
 package com.postdm.backend.domain.estimate.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
-@NoArgsConstructor
-public class PageResponse<T>  {
+@AllArgsConstructor
+public class PageResponse<T> {
     private List<T> content;
     private int page;
     private int size;
@@ -16,16 +18,34 @@ public class PageResponse<T>  {
     private int totalPages;
     private boolean first;
     private boolean last;
-    private boolean sorted;
+    private List<SortInfo> sort;
 
-    public PageResponse(Page<T> page) {
-        this.content = page.getContent();
-        this.page = page.getNumber();
-        this.size = page.getSize();
-        this.totalElements = page.getTotalElements();
-        this.totalPages = page.getTotalPages();
-        this.first = page.isFirst();
-        this.last = page.isLast();
-        this.sorted = page.getSort().isSorted();
+    public static <T> PageResponse<T> from(Page<T> page) {
+        List<SortInfo> sortInfo = page.getSort().stream()
+                .map(SortInfo::new)
+                .collect(Collectors.toList());
+
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isFirst(),
+                page.isLast(),
+                sortInfo
+        );
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class SortInfo {
+        private String property;
+        private String direction;
+
+        public SortInfo(Sort.Order order) {
+            this.property = order.getProperty();
+            this.direction = order.getDirection().name();
+        }
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/dto/PageResponse.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/dto/PageResponse.java
@@ -1,0 +1,31 @@
+package com.postdm.backend.domain.estimate.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PageResponse<T>  {
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean first;
+    private boolean last;
+    private boolean sorted;
+
+    public PageResponse(Page<T> page) {
+        this.content = page.getContent();
+        this.page = page.getNumber();
+        this.size = page.getSize();
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+        this.first = page.isFirst();
+        this.last = page.isLast();
+        this.sorted = page.getSort().isSorted();
+    }
+}

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/entity/Estimate.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/entity/Estimate.java
@@ -49,6 +49,6 @@ public class Estimate {
     }
 
     private String generateTitle(String content) {
-        return content.length() > 10 ? content.substring(0, 10) + "..." : content;
+        return content.length() > 10 ? content.substring(0, 10) + "****" : content;
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/entity/EstimateRepository.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/entity/EstimateRepository.java
@@ -1,9 +1,12 @@
 package com.postdm.backend.domain.estimate.entity;
 
+import com.postdm.backend.domain.member.domain.entity.Member;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 public interface EstimateRepository extends JpaRepository<Estimate, Long> {
-    List<Estimate> findByMemberId(Long memberId);
+    Page<Estimate> findAll(Pageable pageable); // 관리자용
+    Page<Estimate> findByMember(Member member, Pageable pageable); // 사용자용
 }

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/service/EstimateService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/service/EstimateService.java
@@ -1,5 +1,6 @@
 package com.postdm.backend.domain.estimate.service;
 
+import com.postdm.backend.domain.estimate.dto.EstimateListResponseDto;
 import com.postdm.backend.domain.estimate.dto.EstimateResponseDto;
 import com.postdm.backend.domain.estimate.entity.Estimate;
 import com.postdm.backend.domain.estimate.entity.EstimateRepository;
@@ -48,14 +49,14 @@ public class EstimateService {
         );
     }
 
-    public Page<EstimateResponseDto> getEstimates(MemberPrincipalDto principal, Pageable pageable) {
+    public Page<EstimateListResponseDto> getEstimates(MemberPrincipalDto principal, Pageable pageable) {
         Member member = findMemberOrThrow(principal.getId());
 
         Page<Estimate> page = (member.getRole() == MemberRole.ADMIN)
                 ? adminPolicy.getEstimates(member, estimateRepository, pageable)
                 : userPolicy.getEstimates(member, estimateRepository, pageable);
 
-        return page.map(EstimateResponseDto::from);
+        return page.map(EstimateListResponseDto::from);
     }
 
     public EstimateResponseDto getEstimateDetail(Long estimateId, MemberPrincipalDto principal) {

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/service/EstimateService.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/service/EstimateService.java
@@ -13,14 +13,16 @@ import com.postdm.backend.global.common.exception.CustomException;
 import com.postdm.backend.global.common.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import org.springframework.data.domain.Pageable;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class EstimateService {
     private final EstimateRepository estimateRepository;
     private final MemberRepository memberRepository;
@@ -46,18 +48,14 @@ public class EstimateService {
         );
     }
 
-    public List<EstimateResponseDto> getEstimates(MemberPrincipalDto principal) {
+    public Page<EstimateResponseDto> getEstimates(MemberPrincipalDto principal, Pageable pageable) {
         Member member = findMemberOrThrow(principal.getId());
 
-        List<Estimate> estimates = (member.getRole() == MemberRole.ADMIN)
-                ? adminPolicy.getEstimates(member, estimateRepository)
-                : userPolicy.getEstimates(member, estimateRepository);
+        Page<Estimate> page = (member.getRole() == MemberRole.ADMIN)
+                ? adminPolicy.getEstimates(member, estimateRepository, pageable)
+                : userPolicy.getEstimates(member, estimateRepository, pageable);
 
-        return estimates.stream()
-                .map(e -> new EstimateResponseDto(
-                        e.getId(), e.getTitle(), e.getContent(), e.getCreatedAt(), e.getMember().getId()
-                ))
-                .collect(Collectors.toList());
+        return page.map(EstimateResponseDto::from);
     }
 
     public EstimateResponseDto getEstimateDetail(Long estimateId, MemberPrincipalDto principal) {

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/AdminEstimatePolicy.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/AdminEstimatePolicy.java
@@ -3,14 +3,17 @@ package com.postdm.backend.domain.estimate.service.policy;
 import com.postdm.backend.domain.estimate.entity.Estimate;
 import com.postdm.backend.domain.estimate.entity.EstimateRepository;
 import com.postdm.backend.domain.member.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 @Component
+@RequiredArgsConstructor
 public class AdminEstimatePolicy implements EstimatePolicy {
     @Override
-    public List<Estimate> getEstimates(Member member, EstimateRepository repository) {
-        return repository.findAll(); // 관리자: 전체 조회
+    public Page<Estimate> getEstimates(Member member, EstimateRepository repository, Pageable pageable) {
+        return repository.findAll(pageable);
     }
 }

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/EstimatePolicy.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/EstimatePolicy.java
@@ -3,9 +3,10 @@ package com.postdm.backend.domain.estimate.service.policy;
 import com.postdm.backend.domain.estimate.entity.Estimate;
 import com.postdm.backend.domain.estimate.entity.EstimateRepository;
 import com.postdm.backend.domain.member.domain.entity.Member;
+import org.springframework.data.domain.Page;
 
-import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 public interface EstimatePolicy {
-    List<Estimate> getEstimates(Member member, EstimateRepository repository);
+    Page<Estimate> getEstimates(Member member, EstimateRepository repository, Pageable pageable);
 }

--- a/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/UserEstimatePolicy.java
+++ b/backend/src/main/java/com/postdm/backend/domain/estimate/service/policy/UserEstimatePolicy.java
@@ -3,14 +3,17 @@ package com.postdm.backend.domain.estimate.service.policy;
 import com.postdm.backend.domain.estimate.entity.Estimate;
 import com.postdm.backend.domain.estimate.entity.EstimateRepository;
 import com.postdm.backend.domain.member.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 @Component
+@RequiredArgsConstructor
 public class UserEstimatePolicy implements EstimatePolicy {
     @Override
-    public List<Estimate> getEstimates(Member member, EstimateRepository repository) {
-        return repository.findByMemberId(member.getId()); // 일반 유저: 본인만 조회
+    public Page<Estimate> getEstimates(Member member, EstimateRepository repository, Pageable pageable) {
+        return repository.findByMember(member, pageable);
     }
 }

--- a/backend/src/test/java/com/postdm/backend/domain/estimate/controller/EstimateControllerTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/estimate/controller/EstimateControllerTest.java
@@ -2,8 +2,10 @@ package com.postdm.backend.domain.estimate.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.postdm.backend.domain.estimate.dto.EstimateRequestDto;
+import com.postdm.backend.domain.estimate.dto.EstimateResponseDto;
 import com.postdm.backend.domain.estimate.entity.Estimate;
 import com.postdm.backend.domain.estimate.entity.EstimateRepository;
+import com.postdm.backend.domain.estimate.service.EstimateService;
 import com.postdm.backend.domain.member.domain.entity.Member;
 import com.postdm.backend.domain.member.domain.entity.MemberRole;
 import com.postdm.backend.domain.member.domain.repository.MemberRepository;
@@ -16,6 +18,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -24,7 +30,9 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -47,9 +55,16 @@ class EstimateControllerTest {
     @Autowired
     private EstimateRepository estimateRepository;
 
+    @Autowired
+    private EstimateService estimateService;
+
     private Member testMember;
     private Estimate testEstimate;
     private Authentication authentication;
+    private MemberPrincipalDto principal;
+    private EstimateResponseDto dto;
+    private Pageable pageable;
+    private Page<EstimateResponseDto> page;
 
     @BeforeEach
     void setUp() {
@@ -62,12 +77,15 @@ class EstimateControllerTest {
         testEstimate = new Estimate("테스트 견적 내용입니다.", testMember);
         estimateRepository.saveAndFlush(testEstimate);
 
-        MemberPrincipalDto principal = TestPrincipalFactory.create(testMember);
+        principal = TestPrincipalFactory.create(testMember);
 
         authentication = new UsernamePasswordAuthenticationToken(
                 principal, null,
                 Collections.singletonList(new SimpleGrantedAuthority("ROLE_MEMBER"))
         );
+        dto = new EstimateResponseDto(1L, "title", "content", LocalDateTime.now(), 1L);
+        pageable = PageRequest.of(0, 1);
+        page = new PageImpl<>(List.of(dto), pageable, 1);
     }
 
     @Test
@@ -87,12 +105,12 @@ class EstimateControllerTest {
 
     @Test
     @DisplayName("견적서 조회 API 테스트")
-    void 견적서_조회_API_테스트() throws Exception {
+    void 견적서_첫페이지_조회_API_테스트() throws Exception {
         mockMvc.perform(get("/api/v1/estimates")
-                        .with(SecurityMockMvcRequestPostProcessors.authentication(authentication))
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .param("page", "0")
+                        .param("size", "1")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authentication)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.size()").value(1))
-                .andExpect(jsonPath("$.data[0].content").value("테스트 견적 내용입니다."));
+                .andExpect(jsonPath("$.data.content.length()").value(1));
     }
 }

--- a/backend/src/test/java/com/postdm/backend/domain/estimate/repository/EstimateRepositoryTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/estimate/repository/EstimateRepositoryTest.java
@@ -11,9 +11,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,6 +31,9 @@ class EstimateRepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private TestEntityManager em;
 
     private Member testMember;
     private Estimate testEstimate;
@@ -47,45 +53,52 @@ class EstimateRepositoryTest {
     @Test
     @DisplayName("견적서를 저장하고 조회할 수 있다")
     void 견적서를_저장하고_조회() {
-        // When
+        // when
         Estimate foundEstimate = estimateRepository.findById(testEstimate.getId()).orElse(null);
 
-        // Then
+        // then
         assertThat(foundEstimate).isNotNull();
         assertThat(foundEstimate.getContent()).isEqualTo(testEstimate.getContent());
         assertThat(foundEstimate.getMember().getId()).isEqualTo(testMember.getId());
     }
 
     @Test
-    @DisplayName("사용자 ID로 견적서를 조회할 수 있다")
-    void 사용자_ID로_견적서를_조회() {
-        // When
-        List<Estimate> estimates = estimateRepository.findByMemberId(testMember.getId());
+    @DisplayName("견적서를 조회하면 페이지네이션이 적용된다")
+    void 견적서_조회_페이지네이션() {
+        // given
+        for (int i = 0; i < 5; i++) {
+            Estimate estimate = new Estimate("content" + i, testMember);
+            em.persist(estimate);
+        }
 
-        // Then
-        assertThat(estimates).isNotEmpty();
-        assertThat(estimates.get(0).getContent()).isEqualTo(testEstimate.getContent());
-        assertThat(estimates.get(0).getMember().getId()).isEqualTo(testMember.getId());
+        Pageable pageable = PageRequest.of(0, 3);
+
+        // when
+        Page<Estimate> page = estimateRepository.findByMember(testMember, pageable);
+
+        // then
+        assertThat(page.getContent()).hasSize(3);
+        assertThat(page.getTotalElements()).isEqualTo(6);
     }
 
     @Test
     @DisplayName("존재하지 않는 견적서를 조회하면 빈 값이 반환된다")
     void 존재하지_않는_견적서를_조회하면_빈값이_반환() {
-        // When
+        // when
         Optional<Estimate> estimate = estimateRepository.findById(999L); // 없는 ID 조회
 
-        // Then
+        // then
         assertThat(estimate).isEmpty();
     }
 
     @Test
     @DisplayName("견적서를 삭제할 수 있다")
     void 견적서를_삭제() {
-        // When
+        // when
         estimateRepository.delete(testEstimate);
         Optional<Estimate> deletedEstimate = estimateRepository.findById(testEstimate.getId());
 
-        // Then
+        // then
         assertThat(deletedEstimate).isEmpty();
     }
 }

--- a/backend/src/test/java/com/postdm/backend/domain/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/estimate/service/EstimateServiceTest.java
@@ -18,14 +18,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 
+
+import org.springframework.data.domain.Pageable;
 import java.util.Collections;
-import java.util.List;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -93,30 +97,35 @@ class EstimateServiceTest {
         });
     }
 
+
     @Test
-    @DisplayName("사용자가 본인의 견적서를 조회할 수 있다")
-    void 사용자가_본인의_견적서를_조회() {
+    @DisplayName("사용자가 본인의 견적서를 페이지네이션해서 조회할 수 있다")
+    void 사용자는_자신의_견적서만_페이지네이션해서_조회() {
         // given
         MemberPrincipalDto principal = TestPrincipalFactory.create(testMember);
+        Pageable pageable = PageRequest.of(0, 2);
 
         // when
-        List<EstimateResponseDto> estimates = estimateService.getEstimates(principal);
+        Page<EstimateResponseDto> result = estimateService.getEstimates(principal, pageable);
 
         // then
-        assertThat(estimates).isNotEmpty();
-        assertThat(estimates.get(0).getContent()).isEqualTo(testEstimate.getContent());
-        assertThat(estimates.get(0).getMemberId()).isEqualTo(testMember.getId());
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
     }
 
     @Test
     @DisplayName("인증되지 않은 사용자가 견적서를 조회하면 예외가 발생해야 한다")
     void 인증되지_않은_사용자가_견적서를_조회하면_예외_발생() {
+        // given
         SecurityContextHolder.clearContext();
+        Pageable pageable = PageRequest.of(0, 2);
 
+        // when
         Exception exception = assertThrows(Exception.class, () -> {
-            estimateService.getEstimates(null);
+            estimateService.getEstimates(null, pageable);
         });
 
+        // then
         System.out.println("예외 클래스: " + exception.getClass().getName());
         System.out.println("예외 메시지: " + exception.getMessage());
     }

--- a/backend/src/test/java/com/postdm/backend/domain/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/postdm/backend/domain/estimate/service/EstimateServiceTest.java
@@ -1,5 +1,6 @@
 package com.postdm.backend.domain.estimate.service;
 
+import com.postdm.backend.domain.estimate.dto.EstimateListResponseDto;
 import com.postdm.backend.domain.estimate.dto.EstimateRequestDto;
 import com.postdm.backend.domain.estimate.dto.EstimateResponseDto;
 import com.postdm.backend.domain.estimate.entity.Estimate;
@@ -106,7 +107,7 @@ class EstimateServiceTest {
         Pageable pageable = PageRequest.of(0, 2);
 
         // when
-        Page<EstimateResponseDto> result = estimateService.getEstimates(principal, pageable);
+        Page<EstimateListResponseDto> result = estimateService.getEstimates(principal, pageable);
 
         // then
         assertThat(result.getContent()).hasSize(1);


### PR DESCRIPTION
## 📌 개요
- 견적서 조회 API(`GET /api/v1/estimates`)에 페이지네이션 기능을 적용했습니다.
- 관리자와 사용자 모두 페이지 기반으로 견적서가 조회되며, 기존 전체 리스트 반환 방식은 폐기합니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #68 

## ✅ 변경 사항
- 기능 추가: Pageable 기반 견적서 조회 로직 추가
- 리팩터링: 컨트롤러, 서비스, 정책 계층에 페이지네이션 적용을 위한 메서드 시그니처 변경
- 테스트 추가: 컨트롤러/서비스/레포지토리에 대한 페이지네이션 테스트 케이스 작성

## 📝 상세 내용

### 견적서 조회 API 요청
```http
GET /api/v1/estimates?page=0&size=6&sort=id,desc
````

### 응답 구조
```json
{
    "status": 200,
    "message": "견적서 조회 성공",
    "data": {
        "content": [
            {
                "id": 10000,
                "title": "더미 데이터 자동 ****",
                "createdAt": "2025-06-09T23:50:52.875944",
                "memberId": 1
            },
            
            //   "size" 만큼 (견적서 제목만)
        ],
        "page": 0,
        "size": 6,
        "totalElements": 10000,
        "totalPages": 1667,
        "first": true,
        "last": false,
        "sort": [
            {
                "property": "id",
                "direction": "DESC"
            }
        ]
    }
}
```
- 기존: 모든 견적서 목록을 한 번에 반환 (`List<EstimateResponseDto>`)
- 변경: `PageResponse<EstimateListResponseDto>` 형태로 반환
  - 견적서 리스트(목록) 조회 API에서는 `content`(견적서 내용) 제외
  - 커스텀 페이지 응답 DTO(`PageResponse<>`): 중복된 필드를 제거하고 명확한 구조로 수정
  - 응답 구조에서 `data` 안에 `content: []` 배열이 들어가고, 메타 정보(`page`, `size`, `totalElements` 등)가 추가
  - 기본 페이지 사이즈는 6이며, page는 0부터 시작 (`GET /api/v1/estimates`) 
  - 정렬 조건은 기본으로 `id desc` (견적서 id 내림차순)
  - 페이지는 0부터 시작하므로 프론트에서는 +1 보정 필요

## 📸 스크린샷
<img width="320" alt="견적서_페이지네이션" src="https://github.com/user-attachments/assets/d2c93686-9261-4d50-816b-b3f577d6c29c" />
