### PR TITLE
[Hotfix] 더미데이터 테스트 오류 해결

### DIFF
--- a/backend/src/main/java/com/postdm/backend/global/init/DummyDataInitializer.java
+++ b/backend/src/main/java/com/postdm/backend/global/init/DummyDataInitializer.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Component;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Optional;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -23,6 +25,12 @@ public class DummyDataInitializer implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
+        Optional<Member> userOptional = memberRepository.findById(1L);
+        if (userOptional.isEmpty()) {
+            log.warn("ID가 1인 유저가 존재하지 않습니다. 더미 데이터 생성을 건너뜁니다.");
+            return;
+        }
+
         if (estimateRepository.count() > 0) {
             log.info("[INIT] 이미 견적서 데이터가 존재합니다. 초기화를 건너뜁니다.");
             return;


### PR DESCRIPTION
## 📌 개요
- 현재 테스트 진행 시, id = 1 유저가 없는 경우 오류가 발생합니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #73

## ✅ 변경 사항
- 버그 수정: id = 1 유저가 없는 경우, 더미데이터 생성을 건너뛰게 설정했습니다.
